### PR TITLE
Update package configs for renamed public repo

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -25,6 +25,12 @@ jobs:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
 
+      - name: Setup SSH to install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        uses: webfactory/ssh-agent@v0.5.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,9 @@ jobs:
 
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        uses: webfactory/ssh-agent@v0.5.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
         run: npm ci
 
       - name: Run prettier check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,11 +22,14 @@ jobs:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
 
-      - name: Install dependencies
+      - name: Setup SSH to install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         uses: webfactory/ssh-agent@v0.5.0
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Run prettier check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,12 @@ jobs:
           path: node_modules
           key: node-modules-${{ hashFiles('package-lock.json') }}
 
+      - name: Setup SSH to install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
+        uses: webfactory/ssh-agent@v0.5.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
       - name: Install dependencies
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "tribute",
+  "name": "molochv3-ui",
   "version": "0.1.2-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "molochv3-ui",
       "version": "0.1.2-1",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,9 @@
 {
-  "name": "tribute",
+  "name": "molochv3-ui",
   "version": "0.1.2-1",
-  "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/openlawteam/tribute.git"
+    "url": "https://github.com/openlawteam/molochv3-ui.git"
   },
   "homepage": "https://molochv3.org",
   "author": "OpenLaw Team",


### PR DESCRIPTION
Repository is now public and named `molochv3-ui`.

This sub-dependency was causing the dependencies install to fail in the GitHub Actions:
`npm ERR! /usr/bin/git ls-remote -h -t ssh://git@github.com/ethereumjs/ethereumjs-abi.git`

Fixes that issue by using https://github.com/webfactory/ssh-agent in the actions before `npm ci` runs.