### PR TITLE
Adds console.error if no multicall env var is set

### DIFF
--- a/src/components/web3/helpers/multicall.ts
+++ b/src/components/web3/helpers/multicall.ts
@@ -25,6 +25,12 @@ export async function multicall({
     '../../../truffle-contracts/Multicall.json'
   );
 
+  // Let's `console.error` and exit instead of throwing.
+  if (!MULTICALL_CONTRACT_ADDRESS) {
+    console.error('No Multicall address was found. Are you sure it is set?');
+    return;
+  }
+
   try {
     const {methods: multicallMethods} = new web3Instance.eth.Contract(
       lazyMulticallABI as AbiItem[],


### PR DESCRIPTION
**Updates**

- Adds a console error message if there is no multicall env var set (also exits the `multicall` execution)