### PR TITLE
Reverts multicall for contract init

### DIFF
--- a/src/Init.tsx
+++ b/src/Init.tsx
@@ -76,7 +76,7 @@ export default function Init(props: InitProps) {
    * Our hooks
    */
 
-  const {initContracts, contractsFetchStatus} = useInitContracts();
+  const initContracts = useInitContracts();
   const {account, connected, provider, web3Instance} = useWeb3Modal();
   const {defaultChainError} = useIsDefaultChain();
   const {isMountedRef} = useIsMounted();
@@ -111,18 +111,8 @@ export default function Init(props: InitProps) {
   }, [processReadyMap]);
 
   useEffect(() => {
-    connected &&
-      provider &&
-      web3Instance &&
-      contractsFetchStatus === AsyncStatus.FULFILLED &&
-      handleInitContractsCached();
-  }, [
-    connected,
-    contractsFetchStatus,
-    handleInitContractsCached,
-    provider,
-    web3Instance,
-  ]);
+    connected && provider && web3Instance && handleInitContractsCached();
+  }, [connected, handleInitContractsCached, provider, web3Instance]);
 
   useEffect(() => {
     connected &&

--- a/src/components/web3/hooks/useInitContracts.ts
+++ b/src/components/web3/hooks/useInitContracts.ts
@@ -1,6 +1,5 @@
-import Web3 from 'web3';
-import {useCallback, useEffect, useState} from 'react';
-import {useDispatch, useSelector} from 'react-redux';
+import {useCallback} from 'react';
+import {useDispatch} from 'react-redux';
 
 import {
   initContractBankExtension,
@@ -10,40 +9,18 @@ import {
   initContractTribute,
   initRegisteredVotingAdapter,
 } from '../../../store/actions';
-import {AsyncStatus} from '../../../util/types';
-import {ContractAdapterNames, ContractExtensionNames} from '../types';
-import {multicall, MulticallTuple} from '../helpers';
-import {
-  ContractsStateEntry,
-  ReduxDispatch,
-  StoreState,
-} from '../../../store/types';
+import {ReduxDispatch} from '../../../store/types';
 import {useIsDefaultChain} from './useIsDefaultChain';
 import {useWeb3Modal} from '.';
 
-type ContractAddresses = Partial<
-  Record<ContractAdapterNames | ContractExtensionNames, string>
->;
-
-type UseInitContractsReturn = {
-  contractsFetchStatus: AsyncStatus;
-  initContracts: () => Promise<void>;
-};
-
 /**
- * useInitContracts()
+ * useInitContracts
  *
- * Initates contracts used in the app
+ * Initiates all contracts used in the app.
+ *
+ * @todo Use subgraph to pass the address to each init function, so it skips chain calls.
  */
-export function useInitContracts(): UseInitContractsReturn {
-  /**
-   * Selectors
-   */
-
-  const daoRegistryContract = useSelector(
-    (s: StoreState) => s.contracts.DaoRegistryContract
-  );
-
+export function useInitContracts(): () => Promise<void> {
   /**
    * Our hooks
    */
@@ -58,81 +35,14 @@ export function useInitContracts(): UseInitContractsReturn {
   const dispatch = useDispatch<ReduxDispatch>();
 
   /**
-   * State
-   */
-
-  const [
-    contractAddresses,
-    setContractAddresses,
-  ] = useState<ContractAddresses>();
-
-  const [contractsFetchStatus, setContractsFetchStatus] = useState<AsyncStatus>(
-    AsyncStatus.STANDBY
-  );
-
-  /**
    * Cached callbacks
    */
 
   const initContractsCached = useCallback(initContracts, [
-    isDefaultChain,
-    daoRegistryContract,
     dispatch,
+    isDefaultChain,
     web3Instance,
-    contractAddresses,
   ]);
-
-  const getABIItemHelperCached = useCallback(getABIItemHelper, []);
-
-  /**
-   * Effects
-   */
-
-  useEffect(() => {
-    if (!web3Instance) return;
-
-    dispatch(initContractDaoRegistry(web3Instance));
-  }, [dispatch, web3Instance]);
-
-  // Call the chain to get all contract addresses, if subgraph is not available.
-  useEffect(() => {
-    // @todo Check if subgraph query is loaded and back out
-    // if (queryLoading && queryData) return;
-
-    if (!web3Instance) return;
-    if (!daoRegistryContract) return;
-
-    const getCall = getABIItemHelperCached(daoRegistryContract);
-
-    setContractsFetchStatus(AsyncStatus.PENDING);
-
-    multicall({
-      calls: [
-        getCall('getAdapterAddress', ContractAdapterNames.managing),
-        getCall('getAdapterAddress', ContractAdapterNames.voting),
-        getCall('getAdapterAddress', ContractAdapterNames.onboarding),
-        getCall('getExtensionAddress', ContractExtensionNames.bank),
-        getCall('getAdapterAddress', ContractAdapterNames.tribute),
-      ],
-      web3Instance,
-    })
-      .then(([managing, voting, onboarding, bank, tribute]) => {
-        setContractsFetchStatus(AsyncStatus.FULFILLED);
-
-        setContractAddresses((prevState) => ({
-          ...prevState,
-          managing,
-          voting,
-          onboarding,
-          bank,
-          tribute,
-        }));
-      })
-      .catch(() => {
-        setContractsFetchStatus(AsyncStatus.REJECTED);
-        setContractAddresses(undefined);
-      });
-  }, [daoRegistryContract, getABIItemHelperCached, web3Instance]);
 
   /**
    * Functions
@@ -143,51 +53,22 @@ export function useInitContracts(): UseInitContractsReturn {
    */
   async function initContracts() {
     try {
-      if (!isDefaultChain || !daoRegistryContract || !contractAddresses) return;
+      if (!isDefaultChain) return;
 
+      // Must init registry first
+      await dispatch(initContractDaoRegistry(web3Instance));
       // Must be init before voting
-      await dispatch(
-        initContractManaging(web3Instance, contractAddresses?.managing)
-      );
+      await dispatch(initContractManaging(web3Instance));
 
       // Init other contracts
-      await dispatch(
-        initRegisteredVotingAdapter(web3Instance, contractAddresses?.voting)
-      );
-      await dispatch(
-        initContractOnboarding(web3Instance, contractAddresses?.onboarding)
-      );
-
-      await dispatch(
-        initContractBankExtension(web3Instance, contractAddresses?.bank)
-      );
-      await dispatch(
-        initContractTribute(web3Instance, contractAddresses?.tribute)
-      );
+      await dispatch(initRegisteredVotingAdapter(web3Instance));
+      await dispatch(initContractOnboarding(web3Instance));
+      await dispatch(initContractBankExtension(web3Instance));
+      await dispatch(initContractTribute(web3Instance));
     } catch (error) {
       throw error;
     }
   }
 
-  function getABIItemHelper(daoRegistryContract: ContractsStateEntry) {
-    return (
-      functionName: string,
-      contractOrExtensionName: ContractAdapterNames | ContractExtensionNames
-    ): MulticallTuple => {
-      const [abiItem] = daoRegistryContract.abi.filter(
-        (item) => item.name === functionName
-      );
-
-      return [
-        daoRegistryContract.contractAddress,
-        abiItem,
-        [Web3.utils.sha3(contractOrExtensionName) || ''],
-      ];
-    };
-  }
-
-  return {
-    contractsFetchStatus,
-    initContracts: initContractsCached,
-  };
+  return initContractsCached;
 }

--- a/src/test/Wrapper.tsx
+++ b/src/test/Wrapper.tsx
@@ -147,10 +147,9 @@ export default function Wrapper(
     };
   }, [getExtensionAddressMock]);
 
-  // Mock rpc response for getting all contracts in init
+  // Mock rpc response for voting contract multicall inside   init
   useEffect(() => {
     if (!useInit) return;
-
     mockWeb3Provider.injectResult(
       web3Instance.eth.abi.encodeParameters(
         ['uint256', 'bytes[]'],
@@ -158,26 +157,13 @@ export default function Wrapper(
           0,
           [
             web3Instance.utils.padLeft(DEFAULT_ETH_ADDRESS, 64),
-            web3Instance.utils.padLeft(DEFAULT_ETH_ADDRESS, 64),
-            web3Instance.utils.padLeft(DEFAULT_ETH_ADDRESS, 64),
-            web3Instance.utils.padLeft(DEFAULT_ETH_ADDRESS, 64),
-            web3Instance.utils.padLeft(DEFAULT_ETH_ADDRESS, 64),
+            '0x000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000164f6666636861696e566f74696e67436f6e747261637400000000000000000000',
           ],
         ]
       ),
       {abi: MulticallABI, abiMethodName: 'aggregate'}
     );
   }, [mockWeb3Provider, useInit, web3Instance.eth.abi, web3Instance.utils]);
-
-  // Mock rpc response for voting contract init
-  useEffect(() => {
-    if (!useInit) return;
-
-    mockWeb3Provider.injectResult(
-      web3Instance.eth.abi.encodeParameter('string', 'OffchainVotingContract'),
-      {abi: ManagingABI, abiMethodName: 'getVotingAdapterName'}
-    );
-  }, [mockWeb3Provider, useInit, web3Instance.eth.abi]);
 
   // Inject initial results for calls made via getConnectedMember
   useEffect(() => {


### PR DESCRIPTION
**Fixes**

- If an adapter is not present the multicall will fail. This is per the implementation of `getAdapterAddress`. If an adapter is not added the function reverts.

The workaround is to use a subgraph grapql query (e.g. inline `await makePromise(query)`) to make the init process faster. To accomplish this @sophiacodes is working on the subgraph `adapters` mapping, as there's some improvements she's implementing.