### PR TITLE
Improves user rejected request wallet tx error

### DIFF
--- a/src/components/common/ErrorMessageWithDetails.tsx
+++ b/src/components/common/ErrorMessageWithDetails.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {normalizeString} from '../../util/helpers';
 
 import FadeIn from './FadeIn';
 
@@ -13,8 +14,15 @@ export default function ErrorMessageWithDetails(
 ) {
   const {error, renderText} = props;
 
+  // @link https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md#provider-errors
+  const isWalletRejectedRequest =
+    (error as any)?.code === 4001 ||
+    /^(the )?user rejected (the )?request$/g.test(
+      normalizeString(error?.message || '')
+    );
+
   // @note Some wallets will provide proper error codes. The `4001` is a "user rejected transaction".
-  return error && (error as any)?.code !== 4001 ? (
+  return error && !isWalletRejectedRequest ? (
     <FadeIn>
       <div className="text-center">
         <p className="error-message">

--- a/src/pages/membership/CreateMembershipProposal.tsx
+++ b/src/pages/membership/CreateMembershipProposal.tsx
@@ -425,9 +425,11 @@ export default function CreateMembershipProposal() {
         </button>
 
         {/* SUBMIT STATUS */}
-        <div className="form__submit-status-container">
-          {isInProcessOrDone && renderSubmitStatus()}
-        </div>
+        {isInProcessOrDone && (
+          <div className="form__submit-status-container">
+            {renderSubmitStatus()}
+          </div>
+        )}
 
         {/* SUBMIT ERROR */}
         {createMemberError &&


### PR DESCRIPTION
🐞 **Bugs squashed**

 - Improves the detection of an EIP 1193 "user rejected request" by searching the error `message` content. MetaMask attaches a `code` which we use, but not all providers do this (probably good as it's not standard JS `Error`).
 - React element status text wrapper was rendering for membership form when it did not need to - was taking up space.
