### PR TITLE
Governance flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@openlaw/snapshot-js-erc712": "^1.0.18",
         "@walletconnect/web3-provider": "^1.3.2",
         "aos": "^2.3.4",
+        "markdown-to-jsx": "^7.1.1",
         "react": "^17.0.1",
         "react-device-detect": "^1.15.0",
         "react-dom": "^17.0.1",
@@ -15206,6 +15207,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.1.tgz",
+      "integrity": "sha512-PJgNmvdKM7f7dFDgr4N2ZQv5OuJ2dwwBZvKel61BO7JLh2QQLDs880uQO+OjsEKNmhCZ0ZOIKkCXFEuY9G0yEA==",
+      "engines": {
+        "node": ">= 4"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
       }
     },
     "node_modules/md5.js": {
@@ -39515,6 +39527,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "markdown-to-jsx": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.1.tgz",
+      "integrity": "sha512-PJgNmvdKM7f7dFDgr4N2ZQv5OuJ2dwwBZvKel61BO7JLh2QQLDs880uQO+OjsEKNmhCZ0ZOIKkCXFEuY9G0yEA==",
+      "requires": {}
     },
     "md5.js": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@openlaw/snapshot-js-erc712": "^1.0.18",
     "@walletconnect/web3-provider": "^1.3.2",
     "aos": "^2.3.4",
+    "markdown-to-jsx": "^7.1.1",
     "react": "^17.0.1",
     "react-device-detect": "^1.15.0",
     "react-dom": "^17.0.1",

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,22 +1,23 @@
-import React from 'react';
 import {Route, Switch} from 'react-router-dom';
 
-import GetStarted from './pages/start/GetStarted';
+import CreateGovernanceProposal from './pages/governance/CreateGovernanceProposal';
 import CreateMembershipProposal from './pages/membership/CreateMembershipProposal';
+import CreateTransferProposal from './pages/transfers/CreateTransferProposal';
+import CreateTributeProposal from './pages/tributes/CreateTributeProposal';
+import GetStarted from './pages/start/GetStarted';
+import GovernanceProposalDetails from './pages/governance/GovernanceProposalDetails';
+import GovernanceProposals from './pages/governance/GovernanceProposals';
+import MemberProfile from './pages/members/MemberProfile';
+import Members from './pages/members/Members';
 import Membership from './pages/membership/Membership';
 import MembershipDetails from './pages/membership/MembershipDetails';
-import CreateTransferProposal from './pages/transfers/CreateTransferProposal';
-import Transfers from './pages/transfers/Transfers';
-import TransferDetails from './pages/transfers/TransferDetails';
-import CreateTributeProposal from './pages/tributes/CreateTributeProposal';
-import Tributes from './pages/tributes/Tributes';
-import TributeDetails from './pages/tributes/TributeDetails';
-import CreateGovernanceProposal from './pages/governance/CreateGovernanceProposal';
-import GovernanceProposals from './pages/governance/GovernanceProposals';
-import GovernanceProposalDetails from './pages/governance/GovernanceProposalDetails';
-import Members from './pages/members/Members';
-import MemberProfile from './pages/members/MemberProfile';
 import NotFound from './pages/subpages/NotFound';
+import TransferDetails from './pages/transfers/TransferDetails';
+import Transfers from './pages/transfers/Transfers';
+import TributeDetails from './pages/tributes/TributeDetails';
+import Tributes from './pages/tributes/Tributes';
+
+const proposalIdParameter: string = ':proposalId';
 
 export default function Routes() {
   return (
@@ -38,7 +39,7 @@ export default function Routes() {
         <Route
           key="membership-details"
           exact
-          path="/membership/:proposalId"
+          path={`/membership/${proposalIdParameter}`}
           render={() => <MembershipDetails />}
         />,
         <Route
@@ -56,7 +57,7 @@ export default function Routes() {
         <Route
           key="transfer-details"
           exact
-          path="/transfers/:proposalId"
+          path={`/transfers/${proposalIdParameter}`}
           render={() => <TransferDetails />}
         />,
         <Route
@@ -74,7 +75,7 @@ export default function Routes() {
         <Route
           key="tribute-details"
           exact
-          path="/tributes/:proposalId"
+          path={`/tributes/${proposalIdParameter}`}
           render={() => <TributeDetails />}
         />,
         <Route
@@ -92,7 +93,7 @@ export default function Routes() {
         <Route
           key="governance-proposal-details"
           exact
-          path="/governance-proposals/:proposalId"
+          path={`/governance-proposals/${proposalIdParameter}`}
           render={() => <GovernanceProposalDetails />}
         />,
         <Route

--- a/src/components/common/PreviewInputMarkdown.tsx
+++ b/src/components/common/PreviewInputMarkdown.tsx
@@ -1,0 +1,23 @@
+import Markdown from 'markdown-to-jsx';
+
+type PreviewInputMarkdownProps = {
+  value: string;
+};
+
+export default function PreviewInputMarkdown(props: PreviewInputMarkdownProps) {
+  const {value} = props;
+
+  if (!value) return null;
+
+  return (
+    <details>
+      <summary style={{cursor: 'pointer', outline: 'none'}}>
+        <small>Preview Markdown</small>
+      </summary>
+
+      <div style={{marginTop: '1em'}}>
+        <Markdown>{value}</Markdown>
+      </div>
+    </details>
+  );
+}

--- a/src/components/common/PreviewInputMarkdown.unit.test.tsx
+++ b/src/components/common/PreviewInputMarkdown.unit.test.tsx
@@ -1,0 +1,22 @@
+import {render, screen} from '@testing-library/react';
+
+import PreviewInputMarkdown from './PreviewInputMarkdown';
+
+describe('PreviewInputMarkdown unit tests', () => {
+  test('should render value as markdown', () => {
+    render(
+      <PreviewInputMarkdown value={'# Title\n##Sub-title\n- Bullet point'} />
+    );
+
+    expect(screen.getByText(/preview markdown/i)).toBeInTheDocument();
+    expect(screen.getByText(/^title/i)).toBeInTheDocument();
+    expect(screen.getByText(/^sub-title/i)).toBeInTheDocument();
+    expect(screen.getByText(/^bullet point/i)).toBeInTheDocument();
+  });
+
+  test('should render null if no value', () => {
+    render(<PreviewInputMarkdown value="" />);
+
+    expect(() => screen.getByText(/preview markdown/i)).toThrow();
+  });
+});

--- a/src/components/feedback/LoaderWithEmoji.tsx
+++ b/src/components/feedback/LoaderWithEmoji.tsx
@@ -1,7 +1,7 @@
 export default function LoaderWithEmoji() {
   return (
     <div className="loader--emoji">
-      <span role="img" aria-label="hourglass emoji">
+      <span role="img" aria-label="Loading content...">
         ⏳
       </span>
     </div>

--- a/src/components/governance/GovernanceActions.tsx
+++ b/src/components/governance/GovernanceActions.tsx
@@ -1,0 +1,37 @@
+import {OffchainVotingAction, OffchainVotingStatus} from '../proposals/voting';
+import {ProposalData} from '../proposals/types';
+import {useOffchainVotingStartEnd} from '../proposals/hooks';
+
+type GovernanceActionsProps = {
+  proposal: ProposalData;
+};
+
+export function GovernanceActions(props: GovernanceActionsProps) {
+  const {proposal} = props;
+
+  /**
+   * Our hooks
+   */
+
+  const {
+    hasOffchainVotingEnded,
+    hasOffchainVotingStarted,
+    offchainVotingStartEndInitReady,
+  } = useOffchainVotingStartEnd(proposal);
+
+  /**
+   * Render
+   */
+
+  return (
+    <>
+      {offchainVotingStartEndInitReady && hasOffchainVotingStarted && (
+        <OffchainVotingStatus proposal={proposal} />
+      )}
+
+      {offchainVotingStartEndInitReady &&
+        hasOffchainVotingStarted &&
+        !hasOffchainVotingEnded && <OffchainVotingAction proposal={proposal} />}
+    </>
+  );
+}

--- a/src/components/governance/index.ts
+++ b/src/components/governance/index.ts
@@ -1,0 +1,1 @@
+export * from './GovernanceActions';

--- a/src/components/proposals/ProposalDetails.tsx
+++ b/src/components/proposals/ProposalDetails.tsx
@@ -1,6 +1,7 @@
 import {ProposalData} from './types';
 
 import {truncateEthAddress} from '../../util/helpers';
+import Markdown from 'markdown-to-jsx';
 
 type ProposalDetailsProps = {
   proposal: ProposalData;
@@ -35,7 +36,7 @@ export default function ProposalDetails(props: ProposalDetailsProps) {
         <div className="proposaldetails__content">
           <h3>{truncateEthAddress(commonData.msg.payload.name || '', 7)}</h3>
 
-          <p>{commonData.msg.payload.body}</p>
+          <Markdown>{commonData.msg.payload.body}</Markdown>
         </div>
 
         {/* SIDEBAR */}

--- a/src/components/proposals/hooks/useSignAndSendVote.ts
+++ b/src/components/proposals/hooks/useSignAndSendVote.ts
@@ -15,6 +15,7 @@ import {
   VoteChoicesIndex,
 } from '@openlaw/snapshot-js-erc712';
 
+import {BURN_ADDRESS} from '../../../util/constants';
 import {ContractAdapterNames, Web3TxStatus} from '../../web3/types';
 import {DEFAULT_CHAIN, SNAPSHOT_HUB_API_URL, SPACE} from '../../../config';
 import {getAdapterAddressFromContracts} from '../../web3/helpers';
@@ -34,7 +35,8 @@ type SignAndSendVoteDataParam = {
 type UseSignAndSendVoteReturn = {
   signAndSendVote: (data: {
     partialVoteData: SignAndSendVoteDataParam;
-    adapterName: ContractAdapterNames;
+    // e.g. Governance does not have an adpater name
+    adapterName?: ContractAdapterNames;
     proposalIdInDAO: SnapshotVoteData['payload']['proposalHash'];
     proposalIdInSnapshot: string;
   }) => Promise<SignAndSendVoteReturn>;
@@ -105,7 +107,8 @@ export function useSignAndSendVote(): UseSignAndSendVoteReturn {
     proposalIdInSnapshot,
   }: {
     partialVoteData: SignAndSendVoteDataParam;
-    adapterName: ContractAdapterNames;
+    // e.g. Governance does not have an adpater name
+    adapterName?: ContractAdapterNames;
     /**
      * This is the hash of the content as submitted to the DAO.
      * The hash should be the same as the Snapshot draft's, or
@@ -139,10 +142,10 @@ export function useSignAndSendVote(): UseSignAndSendVoteReturn {
 
       setVoteDataStatus(Web3TxStatus.AWAITING_CONFIRM);
 
-      const adapterAddress = getAdapterAddressFromContracts(
-        adapterName,
-        contracts
-      );
+      const adapterAddress = adapterName
+        ? getAdapterAddressFromContracts(adapterName, contracts)
+        : BURN_ADDRESS;
+
       const {choice, delegateAddress, metadata = {}} = partialVoteData;
 
       const {data: snapshotSpace} = await getSpace(SNAPSHOT_HUB_API_URL, SPACE);

--- a/src/components/proposals/hooks/useSignAndSubmitProposal.ts
+++ b/src/components/proposals/hooks/useSignAndSubmitProposal.ts
@@ -34,6 +34,7 @@ import {
 } from '../types';
 import {StoreState} from '../../../store/types';
 import {useWeb3Modal} from '../../web3/hooks/useWeb3Modal';
+import {BURN_ADDRESS} from '../../../util/constants';
 
 type SignAndSendData<T extends ProposalOrDraftSnapshotType> = {
   partialProposalData: PrepareAndSignProposalDataParam;
@@ -191,7 +192,7 @@ export function useSignAndSubmitProposal<
         ? adapterAddress
         : adapterName
         ? getAdapterAddressFromContracts(adapterName, contracts)
-        : '';
+        : BURN_ADDRESS;
 
       const {body, name, metadata, timestamp} = partialProposalData;
 

--- a/src/components/proposals/voting/OffchainVotingAction.tsx
+++ b/src/components/proposals/voting/OffchainVotingAction.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 import {ContractAdapterNames, Web3TxStatus} from '../../web3/types';
 import {getVoteChosen} from '../helpers';
@@ -13,7 +13,7 @@ import {VotingActionButtons} from '.';
 import ErrorMessageWithDetails from '../../common/ErrorMessageWithDetails';
 
 type OffchainVotingActionProps = {
-  adapterName: ContractAdapterNames;
+  adapterName?: ContractAdapterNames;
   proposal: ProposalData;
 };
 
@@ -152,8 +152,8 @@ export function OffchainVotingAction(
       setVoteChoiceClicked(VoteChoices[choice]);
 
       await signAndSendVote({
+        ...(adapterName ? {adapterName} : undefined),
         partialVoteData: {choice},
-        adapterName,
         proposalIdInDAO: proposalHash,
         proposalIdInSnapshot: snapshotProposalId,
       });

--- a/src/hooks/useMemberActionDisabled.unit.test.ts
+++ b/src/hooks/useMemberActionDisabled.unit.test.ts
@@ -1,10 +1,9 @@
 import {renderHook, act} from '@testing-library/react-hooks';
 
-import {isActiveMember} from '../test/web3Responses';
-import {useMemberActionDisabled} from '.';
-import Wrapper from '../test/Wrapper';
 import {SET_CONNECTED_MEMBER} from '../store/actions';
+import {useMemberActionDisabled} from '.';
 import {waitFor} from '@testing-library/react';
+import Wrapper from '../test/Wrapper';
 
 describe('useMemberActionDisabled unit tests', () => {
   test('should return correct data when wallet is disconnected', async () => {
@@ -31,7 +30,7 @@ describe('useMemberActionDisabled unit tests', () => {
 
       const {result} = await renderHook(() => useMemberActionDisabled(), {
         initialProps: {
-          getProps: ({mockWeb3Provider, web3Instance, store}) => {
+          getProps: ({store}) => {
             reduxStore = store;
           },
           useInit: true,

--- a/src/pages/governance/CreateGovernanceProposal.tsx
+++ b/src/pages/governance/CreateGovernanceProposal.tsx
@@ -15,6 +15,7 @@ import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDet
 import FadeIn from '../../components/common/FadeIn';
 import InputError from '../../components/common/InputError';
 import Loader from '../../components/feedback/Loader';
+import PreviewInputMarkdown from '../../components/common/PreviewInputMarkdown';
 import Wrap from '../../components/common/Wrap';
 
 enum Fields {
@@ -66,7 +67,7 @@ export default function CreateGovernanceProposal() {
    * Variables
    */
 
-  const {errors, getValues, register, trigger} = form;
+  const {errors, getValues, register, trigger, watch} = form;
   const isConnected = connected && account;
   const isInProcess =
     proposalSignAndSendStatus === Web3TxStatus.AWAITING_CONFIRM ||
@@ -200,6 +201,8 @@ export default function CreateGovernanceProposal() {
               error={getValidationError(Fields.description, errors)}
               id={`error-${Fields.description}`}
             />
+
+            <PreviewInputMarkdown value={watch(Fields.description)} />
           </div>
         </div>
 

--- a/src/pages/governance/CreateGovernanceProposal.tsx
+++ b/src/pages/governance/CreateGovernanceProposal.tsx
@@ -118,6 +118,8 @@ export default function CreateGovernanceProposal() {
           </label>
           <div className="form__input-row-fieldwrap">
             <textarea
+              aria-describedby={`error-${Fields.description}`}
+              aria-invalid={errors.description ? 'true' : 'false'}
               id={Fields.description}
               name={Fields.description}
               placeholder="Say something about your governance proposal..."
@@ -125,6 +127,11 @@ export default function CreateGovernanceProposal() {
                 required: FormFieldErrors.REQUIRED,
               })}
               // disabled={isInProcessOrDone}
+            />
+
+            <InputError
+              error={getValidationError(Fields.description, errors)}
+              id={`error-${Fields.description}`}
             />
           </div>
         </div>

--- a/src/pages/governance/CreateGovernanceProposal.tsx
+++ b/src/pages/governance/CreateGovernanceProposal.tsx
@@ -1,25 +1,139 @@
 import React from 'react';
+import {useSelector} from 'react-redux';
 
-import Wrap from '../../components/common/Wrap';
+import {StoreState} from '../../store/types';
+import {useWeb3Modal} from '../../components/web3/hooks';
 import FadeIn from '../../components/common/FadeIn';
+import Wrap from '../../components/common/Wrap';
+import {useForm} from 'react-hook-form';
+import {FormFieldErrors} from '../../util/enums';
+import {getValidationError} from '../../util/helpers';
+import InputError from '../../components/common/InputError';
+
+enum Fields {
+  title = 'title',
+  description = 'description',
+}
+
+type FormInputs = {
+  title: string;
+  description: string;
+};
 
 export default function CreateGovernanceProposal() {
+  /**
+   * Selectors
+   */
+
+  const isActiveMember = useSelector(
+    (s: StoreState) => s.connectedMember?.isActiveMember
+  );
+
+  /**
+   * Our hooks
+   */
+
+  const {connected, account} = useWeb3Modal();
+
+  /**
+   * Their hooks
+   */
+
+  const form = useForm<FormInputs>({
+    mode: 'onBlur',
+    reValidateMode: 'onChange',
+  });
+
+  /**
+   * Variables
+   */
+
+  const {errors, getValues, setValue, register, trigger, watch} = form;
+  const isConnected = connected && account;
+
+  /**
+   * Functions
+   */
+
+  function getUnauthorizedMessage() {
+    // user is not connected
+    if (!isConnected) {
+      return 'Connect your wallet to submit a governance proposal.';
+    }
+
+    // user is not an active member
+    if (!isActiveMember) {
+      return 'Either you are not a member, or your membership is not active.';
+    }
+  }
+
   /**
    * Render
    */
 
+  // Render unauthorized message
+  if (!isConnected || !isActiveMember) {
+    return (
+      <RenderWrapper>
+        <div className="form__description--unauthorized">
+          <p>{getUnauthorizedMessage()}</p>
+        </div>
+      </RenderWrapper>
+    );
+  }
+
   return (
     <RenderWrapper>
-      <div>CreateGovernanceProposal @todo</div>
+      <form className="form" onSubmit={(e) => e.preventDefault()}>
+        {/* PROPOSAL TITLE */}
+        <div className="form__input-row">
+          <label className="form__input-row-label" htmlFor={Fields.title}>
+            Title
+          </label>
+          <div className="form__input-row-fieldwrap">
+            {/* @note We don't need the default value as it's handled in the useEffect above. */}
+            <input
+              aria-describedby={`error-${Fields.title}`}
+              aria-invalid={errors.title ? 'true' : 'false'}
+              id={Fields.title}
+              name={Fields.title}
+              ref={register({
+                required: FormFieldErrors.REQUIRED,
+              })}
+              type="text"
+              // disabled={isInProcessOrDone}
+            />
+
+            <InputError
+              error={getValidationError(Fields.title, errors)}
+              id={`error-${Fields.title}`}
+            />
+          </div>
+        </div>
+
+        {/* PROPOSAL DESCRIPTION */}
+        <div className="form__textarea-row">
+          <label className="form__input-row-label" htmlFor={Fields.description}>
+            Description
+          </label>
+          <div className="form__input-row-fieldwrap">
+            <textarea
+              id={Fields.description}
+              name={Fields.description}
+              placeholder="Say something about your governance proposal..."
+              ref={register({
+                required: FormFieldErrors.REQUIRED,
+              })}
+              // disabled={isInProcessOrDone}
+            />
+          </div>
+        </div>
+      </form>
     </RenderWrapper>
   );
 }
 
 function RenderWrapper(props: React.PropsWithChildren<any>): JSX.Element {
-  /**
-   * Render
-   */
-
   return (
     <Wrap className="section-wrapper">
       <FadeIn>
@@ -27,8 +141,18 @@ function RenderWrapper(props: React.PropsWithChildren<any>): JSX.Element {
           <h2 className="titlebar__title">Governance Proposal</h2>
         </div>
 
-        {/* RENDER CHILDREN */}
-        {props.children}
+        <div className="form-wrapper">
+          <div className="form__description">
+            <p>
+              Nulla aliquet porttitor venenatis. Donec a dui et dui fringilla
+              consectetur id nec massa. Aliquam erat volutpat. Sed ut dui ut
+              lacus dictum fermentum vel tincidunt neque. Sed sed lacinia...
+            </p>
+          </div>
+
+          {/* RENDER CHILDREN */}
+          {props.children}
+        </div>
       </FadeIn>
     </Wrap>
   );

--- a/src/pages/governance/CreateGovernanceProposal.unit.test.tsx
+++ b/src/pages/governance/CreateGovernanceProposal.unit.test.tsx
@@ -1,10 +1,10 @@
-import {render, screen, waitFor} from '@testing-library/react';
+import {act, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 
+import {ethBlockNumber, signTypedDataV4} from '../../test/web3Responses';
 import {SET_CONNECTED_MEMBER} from '../../store/actions';
-import Wrapper from '../../test/Wrapper';
 import CreateGovernanceProposal from './CreateGovernanceProposal';
+import Wrapper from '../../test/Wrapper';
 
 describe('CreateGovernanceProposal unit tests', () => {
   test('should not render form if not connected to a wallet', () => {
@@ -86,6 +86,78 @@ describe('CreateGovernanceProposal unit tests', () => {
 
     await waitFor(() => {
       expect(screen.getAllByText(/this field is required\.$/i).length).toBe(2);
+    });
+  });
+
+  test('should submit form', async () => {
+    render(
+      <Wrapper
+        useWallet
+        useInit
+        getProps={({mockWeb3Provider, web3Instance}) => {
+          // Mock the RPC calls from `buildProposalMessageHelper`
+          mockWeb3Provider.injectResult(...ethBlockNumber({web3Instance}));
+          // Mock offchain voting period call
+          mockWeb3Provider.injectResult(
+            web3Instance.eth.abi.encodeParameter('uint256', 123)
+          );
+          // Mock signature
+          mockWeb3Provider.injectResult(...signTypedDataV4({web3Instance}));
+        }}>
+        <CreateGovernanceProposal />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/^governance proposal$/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+    });
+
+    // Type in the inputs
+    await userEvent.type(screen.getByLabelText(/title/i), 'Great title', {
+      delay: 100,
+    });
+
+    await userEvent.type(
+      screen.getByLabelText(/description/i),
+      'Great description!',
+      {delay: 100}
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue(/great title/i)).toBeInTheDocument();
+      expect(
+        screen.getByDisplayValue(/great description!/i)
+      ).toBeInTheDocument();
+    });
+
+    act(() => {
+      // Click submit
+      userEvent.click(screen.getByRole('button', {name: /submit/i}));
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/awaiting your confirmation/i)
+      ).toBeInTheDocument();
+      expect(screen.getByLabelText(/title/i)).toBeDisabled();
+      expect(screen.getByLabelText(/description/i)).toBeDisabled();
+      expect(screen.getByRole('button', {name: /submit/i})).toBeDisabled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/submitting/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/title/i)).toBeDisabled();
+      expect(screen.getByLabelText(/description/i)).toBeDisabled();
+      expect(screen.getByRole('button', {name: /submit/i})).toBeDisabled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/done/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/title/i)).toBeDisabled();
+      expect(screen.getByLabelText(/description/i)).toBeDisabled();
+      expect(screen.getByRole('button', {name: /submit/i})).toBeDisabled();
     });
   });
 });

--- a/src/pages/governance/CreateGovernanceProposal.unit.test.tsx
+++ b/src/pages/governance/CreateGovernanceProposal.unit.test.tsx
@@ -1,4 +1,5 @@
 import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import {SET_CONNECTED_MEMBER} from '../../store/actions';
@@ -63,6 +64,28 @@ describe('CreateGovernanceProposal unit tests', () => {
       expect(screen.getByText(/^governance proposal$/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+    });
+  });
+
+  test('should render form errors for blank fields', async () => {
+    render(
+      <Wrapper useWallet useInit>
+        <CreateGovernanceProposal />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/^governance proposal$/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+    });
+
+    userEvent.click(screen.getByLabelText(/title/i));
+    userEvent.click(screen.getByLabelText(/description/i));
+    userEvent.click(screen.getByLabelText(/title/i));
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/this field is required\.$/i).length).toBe(2);
     });
   });
 });

--- a/src/pages/governance/CreateGovernanceProposal.unit.test.tsx
+++ b/src/pages/governance/CreateGovernanceProposal.unit.test.tsx
@@ -1,0 +1,68 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import {SET_CONNECTED_MEMBER} from '../../store/actions';
+import Wrapper from '../../test/Wrapper';
+import CreateGovernanceProposal from './CreateGovernanceProposal';
+
+describe('CreateGovernanceProposal unit tests', () => {
+  test('should not render form if not connected to a wallet', () => {
+    render(
+      <Wrapper>
+        <CreateGovernanceProposal />
+      </Wrapper>
+    );
+
+    expect(screen.getByText(/^governance proposal$/i)).toBeInTheDocument();
+    expect(() => screen.getByLabelText(/title/i)).toThrow();
+    expect(() => screen.getByLabelText(/description/i)).toThrow();
+    expect(
+      screen.getByText(/connect your wallet to submit a governance proposal/i)
+    ).toBeInTheDocument();
+  });
+
+  test('should not render form if not a member', () => {
+    let store: any;
+
+    render(
+      <Wrapper
+        useWallet
+        useInit
+        getProps={(p) => {
+          store = p.store;
+        }}>
+        <CreateGovernanceProposal />
+      </Wrapper>
+    );
+
+    // Set a non-active member
+    store.dispatch({
+      type: SET_CONNECTED_MEMBER,
+      ...store.getState().connectedMember,
+      isActiveMember: false,
+    });
+
+    expect(screen.getByText(/^governance proposal$/i)).toBeInTheDocument();
+    expect(() => screen.getByLabelText(/title/i)).toThrow();
+    expect(() => screen.getByLabelText(/description/i)).toThrow();
+    expect(
+      screen.getByText(
+        /either you are not a member, or your membership is not active\./i
+      )
+    ).toBeInTheDocument();
+  });
+
+  test('should render form', async () => {
+    render(
+      <Wrapper useWallet useInit>
+        <CreateGovernanceProposal />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/^governance proposal$/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/governance/GovernanceProposalDetails.tsx
+++ b/src/pages/governance/GovernanceProposalDetails.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {useHistory, useParams} from 'react-router-dom';
 
 import {AsyncStatus} from '../../util/types';
+import {GovernanceActions} from '../../components/governance';
 import {useProposalOrDraft} from '../../components/proposals/hooks';
 import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDetails';
 import FadeIn from '../../components/common/FadeIn';
@@ -72,7 +73,10 @@ export default function GovernanceProposalDetails() {
   if (proposalData) {
     return (
       <RenderWrapper>
-        <ProposalDetails proposal={proposalData} renderActions={() => <></>} />
+        <ProposalDetails
+          proposal={proposalData}
+          renderActions={() => <GovernanceActions proposal={proposalData} />}
+        />
       </RenderWrapper>
     );
   }

--- a/src/pages/governance/GovernanceProposalDetails.tsx
+++ b/src/pages/governance/GovernanceProposalDetails.tsx
@@ -1,19 +1,84 @@
+import {SnapshotType} from '@openlaw/snapshot-js-erc712';
 import React from 'react';
-import {useHistory} from 'react-router-dom';
+import {useHistory, useParams} from 'react-router-dom';
 
-import Wrap from '../../components/common/Wrap';
+import {AsyncStatus} from '../../util/types';
+import {useProposalOrDraft} from '../../components/proposals/hooks';
+import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDetails';
 import FadeIn from '../../components/common/FadeIn';
+import LoaderWithEmoji from '../../components/feedback/LoaderWithEmoji';
+import NotFound from '../subpages/NotFound';
+import ProposalDetails from '../../components/proposals/ProposalDetails';
+import Wrap from '../../components/common/Wrap';
 
 export default function GovernanceProposalDetails() {
+  /**
+   * Their hooks
+   */
+
+  // Get hash for fetching the proposal.
+  const {proposalId} = useParams<{proposalId: string}>();
+
+  /**
+   * Our hooks
+   */
+
+  const {
+    proposalData,
+    proposalError,
+    proposalNotFound,
+    proposalStatus,
+  } = useProposalOrDraft(proposalId, SnapshotType.proposal);
+
   /**
    * Render
    */
 
-  return (
-    <RenderWrapper>
-      <div>GovernanceProposalDetails @todo</div>
-    </RenderWrapper>
-  );
+  // Render loading
+  if (proposalStatus === AsyncStatus.PENDING) {
+    return (
+      <RenderWrapper>
+        <div style={{width: '3rem', margin: '0 auto'}}>
+          <LoaderWithEmoji />
+        </div>
+      </RenderWrapper>
+    );
+  }
+
+  // Render 404 no proposal found
+  if (proposalNotFound) {
+    return (
+      <RenderWrapper>
+        <NotFound />
+      </RenderWrapper>
+    );
+  }
+
+  // Render error
+  if (proposalStatus === AsyncStatus.REJECTED || proposalError) {
+    return (
+      <RenderWrapper>
+        <div className="text-center">
+          <ErrorMessageWithDetails
+            error={proposalError}
+            renderText="Something went wrong."
+          />
+        </div>
+      </RenderWrapper>
+    );
+  }
+
+  // Render proposal
+  if (proposalData) {
+    return (
+      <RenderWrapper>
+        <ProposalDetails proposal={proposalData} renderActions={() => <></>} />
+      </RenderWrapper>
+    );
+  }
+
+  // Render nothing. Should never reach this case.
+  return <></>;
 }
 
 function RenderWrapper(props: React.PropsWithChildren<any>): JSX.Element {
@@ -29,6 +94,7 @@ function RenderWrapper(props: React.PropsWithChildren<any>): JSX.Element {
 
   function viewAll(event: React.MouseEvent<HTMLButtonElement>) {
     event.preventDefault();
+
     history.push('/governance-proposals');
   }
 
@@ -41,6 +107,7 @@ function RenderWrapper(props: React.PropsWithChildren<any>): JSX.Element {
       <FadeIn>
         <div className="titlebar">
           <h2 className="titlebar__title">Governance</h2>
+
           <button className="titlebar__action" onClick={viewAll}>
             View all
           </button>

--- a/src/pages/governance/GovernanceProposalDetails.unit.test.tsx
+++ b/src/pages/governance/GovernanceProposalDetails.unit.test.tsx
@@ -1,12 +1,12 @@
 import {render, screen, waitFor} from '@testing-library/react';
 
-import GovernanceProposalDetails from './GovernanceProposalDetails';
-import Wrapper from '../../test/Wrapper';
 import {rest, server} from '../../test/server';
 import {SNAPSHOT_HUB_API_URL} from '../../config';
+import GovernanceProposalDetails from './GovernanceProposalDetails';
+import Wrapper from '../../test/Wrapper';
 
 describe('GovernanceProposalDetails unit tests', () => {
-  test('should render page', async () => {
+  test('should render proposal', async () => {
     render(
       <Wrapper>
         <GovernanceProposalDetails />
@@ -14,6 +14,7 @@ describe('GovernanceProposalDetails unit tests', () => {
     );
 
     expect(screen.getByText(/governance/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /view all/i})).toBeInTheDocument();
 
     await waitFor(() => {
       expect(
@@ -26,6 +27,33 @@ describe('GovernanceProposalDetails unit tests', () => {
       expect(
         screen.getByText(/test snapshot proposal body content\./i)
       ).toBeInTheDocument();
+    });
+
+    /**
+     * Vote actions
+     *
+     * @note is an ended vote as per default mocked repsonse in our test suite.
+     */
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/counting down until voting ends/i)
+      ).toBeInTheDocument();
+      expect(screen.getAllByText(/0%/i).length).toBe(2);
+      expect(screen.getByLabelText(/0% yes votes/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/0% no votes/i)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/counting down until voting ends/i)
+      ).toBeInTheDocument();
+      expect(screen.getAllByText(/0%/i).length).toBe(2);
+      expect(screen.getByLabelText(/0% yes votes/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/0% no votes/i)).toBeInTheDocument();
+
+      // Wait for status
+      expect(screen.getByLabelText(/failed/i)).toBeInTheDocument();
     });
   });
 

--- a/src/pages/governance/GovernanceProposalDetails.unit.test.tsx
+++ b/src/pages/governance/GovernanceProposalDetails.unit.test.tsx
@@ -1,0 +1,91 @@
+import {render, screen, waitFor} from '@testing-library/react';
+
+import GovernanceProposalDetails from './GovernanceProposalDetails';
+import Wrapper from '../../test/Wrapper';
+import {rest, server} from '../../test/server';
+import {SNAPSHOT_HUB_API_URL} from '../../config';
+
+describe('GovernanceProposalDetails unit tests', () => {
+  test('should render page', async () => {
+    render(
+      <Wrapper>
+        <GovernanceProposalDetails />
+      </Wrapper>
+    );
+
+    expect(screen.getByText(/governance/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/loading content\.\.\./i)
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/^test snapshot proposal$/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/test snapshot proposal body content\./i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('should render 404 if not found', async () => {
+    // Mock 404 response from Snapshot Hub (they don't use 404 error code)
+    server.use(
+      rest.get(
+        `${SNAPSHOT_HUB_API_URL}/api/:spaceName/proposal/:id`,
+        async (_req, res, ctx) => res(ctx.json({}))
+      )
+    );
+
+    render(
+      <Wrapper>
+        <GovernanceProposalDetails />
+      </Wrapper>
+    );
+
+    expect(screen.getByText(/governance/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/loading content\.\.\./i)
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/44/i)).toBeInTheDocument();
+      expect(screen.getByText(/😵/i)).toBeInTheDocument();
+    });
+  });
+
+  test('should render error if proposal could not be fetched', async () => {
+    // Mock 500 response from Snapshot Hub
+    server.use(
+      rest.get(
+        `${SNAPSHOT_HUB_API_URL}/api/:spaceName/proposal/:id`,
+        async (_req, res, ctx) => res(ctx.status(500))
+      )
+    );
+
+    render(
+      <Wrapper>
+        <GovernanceProposalDetails />
+      </Wrapper>
+    );
+
+    expect(screen.getByText(/governance/i)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/loading content\.\.\./i)
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/^something went wrong\.$/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/something went wrong while getting the proposal/i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/test/Wrapper.tsx
+++ b/src/test/Wrapper.tsx
@@ -97,7 +97,7 @@ export default function Wrapper(
         providerOptions: {},
         onConnectTo: () => {},
         onDisconnect: () => {},
-        networkId: mockChains['GANACHE'],
+        networkId: mockChains.GANACHE,
         provider: mockWeb3Provider,
         web3Instance: mockWeb3,
         web3Modal: null,

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -1,0 +1,8 @@
+/**
+ * BURN_ADDRESS
+ *
+ * - e.g. Helpful when detecting no address.
+ * - e.g. Helpful for ERC-712 signatures which have no action id (like Governance).
+ */
+export const BURN_ADDRESS: '0x0000000000000000000000000000000000000000' =
+  '0x0000000000000000000000000000000000000000';


### PR DESCRIPTION
Fixes #167 

🥳 **Adds**

 - Gov. form + unit tests
 - Gov. details page + unit tests
 - Package: `markdown-to-jsx@^7.1.1`
 - `PreviewInputMarkdown` common component + unit tests
 - `BURN_ADDRESS` (`0x0`) constant to help when no `actionId` exists for governance voting

✨ **Updates**

 - Nitpick in test `Wrapper`
 - aria-label for hourglass loader emoji
 - Routes now uses variable for `:proposalId` to make it less error-prone to typing errors
 - Markdown parsing to proposal details body
 - Off-chain voting can vote with `0x0...` `actionId` to accommodate governance proposals
 - `adapterName:?` is optional for voting to accommodate governance proposals.

⛔️ **Removes**

  - Remove unused test code

