### PR TITLE
Removes explicit checking for MetaMaskRPCError before showing form errors

### DIFF
--- a/src/components/adapters-extensions/ConfigurationForm.tsx
+++ b/src/components/adapters-extensions/ConfigurationForm.tsx
@@ -6,7 +6,6 @@ import {AbiItem} from 'web3-utils/types';
 import {DaoConstants} from './enums';
 import {AdaptersOrExtensions} from './types';
 import {StoreState} from '../../store/types';
-import {MetaMaskRPCError} from '../../util/types';
 import {Web3TxStatus} from '../web3/types';
 import {FormFieldErrors} from '../../util/enums';
 import {getValidationError} from '../../util/helpers';
@@ -291,15 +290,14 @@ export default function ConfigurationForm({
     </div> */}
 
       {/* SUBMIT ERROR */}
-      {configureAdapterError &&
-        (configureAdapterError as MetaMaskRPCError).code !== 4001 && (
-          <div className="form__submit-error-container">
-            <ErrorMessageWithDetails
-              renderText="Something went wrong while submitting the adapter configuration."
-              error={configureAdapterError}
-            />
-          </div>
-        )}
+      {configureAdapterError && (
+        <div className="form__submit-error-container">
+          <ErrorMessageWithDetails
+            renderText="Something went wrong while submitting the adapter configuration."
+            error={configureAdapterError}
+          />
+        </div>
+      )}
 
       {/** REMOVE ADAPTER BUTTON - only show if DAO isn't finalized */}
       <div className="adapter-extension__remove">

--- a/src/components/common/ErrorMessageWithDetails.tsx
+++ b/src/components/common/ErrorMessageWithDetails.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+
+import {MetaMaskRPCError} from '../../util/types';
 import {normalizeString} from '../../util/helpers';
 
 import FadeIn from './FadeIn';
@@ -16,7 +18,7 @@ export default function ErrorMessageWithDetails(
 
   // @link https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md#provider-errors
   const isWalletRejectedRequest =
-    (error as any)?.code === 4001 ||
+    (error as MetaMaskRPCError)?.code === 4001 ||
     /^(the )?user rejected (the )?request$/g.test(
       normalizeString(error?.message || '')
     );

--- a/src/pages/membership/CreateMembershipProposal.tsx
+++ b/src/pages/membership/CreateMembershipProposal.tsx
@@ -18,7 +18,6 @@ import {
 import {ContractAdapterNames, Web3TxStatus} from '../../components/web3/types';
 import {FormFieldErrors} from '../../util/enums';
 import {isEthAddressValid} from '../../util/validation';
-import {MetaMaskRPCError} from '../../util/types';
 import {SHARES_ADDRESS} from '../../config';
 import {StoreState} from '../../store/types';
 import {TX_CYCLE_MESSAGES} from '../../components/web3/config';
@@ -432,15 +431,14 @@ export default function CreateMembershipProposal() {
         )}
 
         {/* SUBMIT ERROR */}
-        {createMemberError &&
-          (createMemberError as MetaMaskRPCError).code !== 4001 && (
-            <div className="form__submit-error-container">
-              <ErrorMessageWithDetails
-                renderText="Something went wrong while submitting the proposal."
-                error={createMemberError}
-              />
-            </div>
-          )}
+        {createMemberError && (
+          <div className="form__submit-error-container">
+            <ErrorMessageWithDetails
+              renderText="Something went wrong while submitting the proposal."
+              error={createMemberError}
+            />
+          </div>
+        )}
       </form>
     </RenderWrapper>
   );

--- a/src/pages/transfers/CreateTransferProposal.tsx
+++ b/src/pages/transfers/CreateTransferProposal.tsx
@@ -24,7 +24,6 @@ import {
 import {ContractAdapterNames, Web3TxStatus} from '../../components/web3/types';
 import {FormFieldErrors} from '../../util/enums';
 import {isEthAddressValid} from '../../util/validation';
-import {MetaMaskRPCError} from '../../util/types';
 import {StoreState} from '../../store/types';
 import {TX_CYCLE_MESSAGES} from '../../components/web3/config';
 import {multicall, MulticallTuple} from '../../components/web3/helpers';
@@ -773,15 +772,14 @@ export default function CreateTransferProposal() {
         )}
 
         {/* SUBMIT ERROR */}
-        {createTransferError &&
-          (createTransferError as MetaMaskRPCError).code !== 4001 && (
-            <div className="form__submit-error-container">
-              <ErrorMessageWithDetails
-                renderText="Something went wrong while submitting the proposal."
-                error={createTransferError}
-              />
-            </div>
-          )}
+        {createTransferError && (
+          <div className="form__submit-error-container">
+            <ErrorMessageWithDetails
+              renderText="Something went wrong while submitting the proposal."
+              error={createTransferError}
+            />
+          </div>
+        )}
       </form>
     </RenderWrapper>
   );

--- a/src/pages/tributes/CreateTributeProposal.tsx
+++ b/src/pages/tributes/CreateTributeProposal.tsx
@@ -20,7 +20,6 @@ import {
 import {ContractAdapterNames, Web3TxStatus} from '../../components/web3/types';
 import {FormFieldErrors} from '../../util/enums';
 import {isEthAddressValid} from '../../util/validation';
-import {MetaMaskRPCError} from '../../util/types';
 import {truncateEthAddress} from '../../util/helpers';
 import {SHARES_ADDRESS} from '../../config';
 import {StoreState} from '../../store/types';
@@ -726,15 +725,14 @@ export default function CreateTributeProposal() {
         )}
 
         {/* SUBMIT ERROR */}
-        {createTributeError &&
-          (createTributeError as MetaMaskRPCError).code !== 4001 && (
-            <div className="form__submit-error-container">
-              <ErrorMessageWithDetails
-                renderText="Something went wrong while submitting the proposal."
-                error={createTributeError}
-              />
-            </div>
-          )}
+        {createTributeError && (
+          <div className="form__submit-error-container">
+            <ErrorMessageWithDetails
+              renderText="Something went wrong while submitting the proposal."
+              error={createTributeError}
+            />
+          </div>
+        )}
       </form>
     </RenderWrapper>
   );


### PR DESCRIPTION
Fixes #172

⛔️ **Removes**

 - Explicit checking for `MetaMaskRPCError` in forms. It is handled in `ErrorMessageWithDetails`
