### PR TITLE
Adds useProposalFlag helper, ProposalFlag enum now matches contract counterpart

### DIFF
--- a/src/components/proposals/helpers/index.ts
+++ b/src/components/proposals/helpers/index.ts
@@ -1,1 +1,2 @@
 export * from './getVoteChosen';
+export * from './proposalHasFlag';

--- a/src/components/proposals/helpers/proposalHasFlag.ts
+++ b/src/components/proposals/helpers/proposalHasFlag.ts
@@ -1,0 +1,19 @@
+import {ProposalFlag} from '../types';
+
+/**
+ * proposalHasFlag
+ *
+ * @param flagToCheck
+ * @param daoProposalFlag
+ * @returns {boolean}
+ *
+ * @see `ProposalFlag` `DaoRegistry.sol`
+ * @see `getFlag` `DaoConstants.sol`
+ * @see `setFlag` `DaoConstants.sol`
+ */
+export function proposalHasFlag(
+  flagToCheck: ProposalFlag,
+  daoProposalFlag: number | string
+): boolean {
+  return flagToCheck === Math.log2(Number(daoProposalFlag) + 1) - 1;
+}

--- a/src/components/proposals/helpers/proposalHasFlag.unit.test.ts
+++ b/src/components/proposals/helpers/proposalHasFlag.unit.test.ts
@@ -1,0 +1,22 @@
+import {ProposalFlag} from '../types';
+import {proposalHasFlag} from './proposalHasFlag';
+
+describe('proposalHasFlag unit tests', () => {
+  test('should return true if flag matches', () => {
+    expect(proposalHasFlag(ProposalFlag.EXISTS, '1')).toBe(true);
+    expect(proposalHasFlag(ProposalFlag.SPONSORED, '3')).toBe(true);
+    expect(proposalHasFlag(ProposalFlag.PROCESSED, '7')).toBe(true);
+    expect(proposalHasFlag(ProposalFlag.EXISTS, 1)).toBe(true);
+    expect(proposalHasFlag(ProposalFlag.SPONSORED, 3)).toBe(true);
+    expect(proposalHasFlag(ProposalFlag.PROCESSED, 7)).toBe(true);
+  });
+
+  test('should return false if flag does not match', () => {
+    expect(proposalHasFlag(ProposalFlag.EXISTS, '7')).toBe(false);
+    expect(proposalHasFlag(ProposalFlag.SPONSORED, '1')).toBe(false);
+    expect(proposalHasFlag(ProposalFlag.PROCESSED, '3')).toBe(false);
+    expect(proposalHasFlag(ProposalFlag.EXISTS, 7)).toBe(false);
+    expect(proposalHasFlag(ProposalFlag.SPONSORED, 1)).toBe(false);
+    expect(proposalHasFlag(ProposalFlag.PROCESSED, 3)).toBe(false);
+  });
+});

--- a/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
+++ b/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
@@ -1,14 +1,15 @@
 import {useSelector} from 'react-redux';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
+import {BURN_ADDRESS} from '../../../util/constants';
 import {multicall, MulticallTuple} from '../../web3/helpers';
+import {normalizeString} from '../../../util/helpers';
 import {ProposalFlowStatus, ProposalData, ProposalFlag} from '../types';
+import {proposalHasFlag} from '../helpers';
 import {StoreState} from '../../../store/types';
 import {useOffchainVotingStartEnd} from '.';
 import {useWeb3Modal} from '../../web3/hooks';
 import {VotingState} from '../voting/types';
-import {BURN_ADDRESS} from '../../../util/constants';
-import {normalizeString} from '../../../util/helpers';
 
 // @todo Logic to fall back to on-chain polling this if subgraph is not available
 
@@ -110,13 +111,13 @@ export function useProposalWithOffchainVoteStatus(
    */
 
   const atExistsInDAO = daoProposal
-    ? ProposalFlag[daoProposal.flags] === ProposalFlag[ProposalFlag.EXISTS]
+    ? proposalHasFlag(ProposalFlag.EXISTS, daoProposal.flags)
     : false;
   const atSponsoredInDAO = daoProposal
-    ? ProposalFlag[daoProposal.flags] === ProposalFlag[ProposalFlag.SPONSORED]
+    ? proposalHasFlag(ProposalFlag.SPONSORED, daoProposal.flags)
     : false;
   const atProcessedInDAO = daoProposal
-    ? ProposalFlag[daoProposal.flags] === ProposalFlag[ProposalFlag.PROCESSED]
+    ? proposalHasFlag(ProposalFlag.PROCESSED, daoProposal.flags)
     : false;
 
   /**

--- a/src/components/proposals/types.ts
+++ b/src/components/proposals/types.ts
@@ -11,21 +11,18 @@ import {
  */
 
 /**
- * Reverse mapping of DaoRegistry proposal flags.
- * The formula used to create the `flags` entry is:
- *   `prevFlags + 2**nextFlagIndex`
- *    i.e. to get the flag after `flags: 1` the formula is: `1 + 2**1 = 3`
+ * Mapping of DaoRegistry proposal flags.
+ * This should match the enum (including order) in the `DaoRegistry`. If it does not match,
+ * the results of checking the proposal's state via flag will be wrong.
  *
- * @note Order matters
- *
- * @see `ProposalFlag` in molochv3-contracts `DaoRegistry.sol`
- * @see `getFlag` in molochv3-contracts `DaoConstants.sol`
- * @see `setFlag` in molochv3-contracts `DaoConstants.sol`
+ * @see `ProposalFlag` `DaoRegistry.sol`
+ * @see `getFlag` `DaoConstants.sol`
+ * @see `setFlag` `DaoConstants.sol`
  */
 export enum ProposalFlag {
-  EXISTS = 1,
-  SPONSORED = 3,
-  PROCESSED = 7,
+  EXISTS,
+  SPONSORED,
+  PROCESSED,
 }
 
 // @todo Need more information about the vote challenge flow.


### PR DESCRIPTION
Fixes #109 

🥳 **Adds**

 - `proposalHasFlag` helper + unit tests

✨ **Updates**

 - Hardcoded `ProposalFlag` reverse mapping now matches the contract enum by the same name. To get the proposal's flag state we use the new helper `proposalHasFlag`

