### PR TITLE
adds useGovernanceProposals + unit tests

### DIFF
--- a/src/components/governance/GovernanceProposals.tsx
+++ b/src/components/governance/GovernanceProposals.tsx
@@ -53,8 +53,7 @@ export default function GovernanceProposals(
     actionId,
   });
 
-  // @todo Use batch voting results hook to do the same as `useOffchainVotingResults`
-  // @todo Share logic between batch and single off-chain voting result hooks
+  // @todo Use batch voting results from `useOffchainVotingResults` (need to update to allow array)
   // @todo Pass `OffchainVotingResult` down to `OffchainVotingStatus` via `ProposalCard`
 
   /**

--- a/src/components/governance/GovernanceProposals.tsx
+++ b/src/components/governance/GovernanceProposals.tsx
@@ -1,0 +1,205 @@
+import React, {useEffect, useState} from 'react';
+
+import {AsyncStatus} from '../../util/types';
+import {BURN_ADDRESS} from '../../util/constants';
+import {ProposalData} from '../proposals/types';
+import {ProposalHeaderNames} from '../../util/enums';
+import {truncateEthAddress} from '../../util/helpers';
+import {useGovernanceProposals} from './hooks';
+import ErrorMessageWithDetails from '../common/ErrorMessageWithDetails';
+import LoaderWithEmoji from '../feedback/LoaderWithEmoji';
+import ProposalCard from '../proposals/ProposalCard';
+
+type GovernanceProposalsProps = {
+  /**
+   * The `actionId` to get proposals for in Snapshot Hub.
+   */
+  actionId?: string;
+  onProposalClick: (id: string) => void;
+};
+
+type FilteredProposals = {
+  failedProposals: ProposalData[];
+  passedProposals: ProposalData[];
+  votingProposals: ProposalData[];
+};
+
+export default function GovernanceProposals(
+  props: GovernanceProposalsProps
+): JSX.Element {
+  const {actionId = BURN_ADDRESS, onProposalClick} = props;
+
+  /**
+   * State
+   */
+
+  const [filteredProposals, setFilteredProposals] = useState<FilteredProposals>(
+    {
+      failedProposals: [],
+      passedProposals: [],
+      votingProposals: [],
+    }
+  );
+
+  /**
+   * Our hooks
+   */
+
+  const {
+    governanceProposals,
+    governanceProposalsError,
+    governanceProposalsStatus,
+  } = useGovernanceProposals({
+    actionId,
+  });
+
+  // @todo Use batch voting results hook to do the same as `useOffchainVotingResults`
+  // @todo Share logic between batch and single off-chain voting result hooks
+  // @todo Pass `OffchainVotingResult` down to `OffchainVotingStatus` via `ProposalCard`
+
+  /**
+   * Variables
+   */
+
+  const {failedProposals, passedProposals, votingProposals} = filteredProposals;
+
+  const isLoading: boolean = governanceProposalsStatus === AsyncStatus.PENDING;
+  const isError: boolean = governanceProposalsStatus === AsyncStatus.REJECTED;
+  const isLoadingDone: boolean =
+    governanceProposalsStatus === AsyncStatus.FULFILLED;
+
+  /**
+   * Effects
+   */
+
+  // Separate proposals into categories: voting, passed, failed
+  useEffect(() => {
+    if (governanceProposalsStatus !== AsyncStatus.FULFILLED) return;
+
+    const filteredProposalsToSet: FilteredProposals = {
+      failedProposals: [],
+      passedProposals: [],
+      votingProposals: [],
+    };
+
+    governanceProposals.forEach((p) => {
+      const end = p.snapshotProposal?.msg.payload.end || 0;
+      const hasVoteEnded = end < Math.ceil(Date.now() / 1000);
+
+      // @todo Determine passed / failed status
+
+      // voting proposal
+      if (!hasVoteEnded) {
+        filteredProposalsToSet.votingProposals.push(p);
+      }
+
+      // passed proposal
+      // if (true) {
+      //   filteredProposalsToSet.passedProposals.push(p);
+      // }
+
+      // failed proposal
+      // if (true) {
+      //   filteredProposalsToSet.failedProposals.push(p);
+      // }
+    });
+
+    setFilteredProposals((prevState) => ({
+      ...prevState,
+      ...filteredProposalsToSet,
+    }));
+  }, [governanceProposals, governanceProposalsStatus]);
+
+  /**
+   * Functions
+   */
+
+  function renderProposalCards(
+    proposals: ProposalData[]
+  ): React.ReactNode | null {
+    return proposals.map((proposal) => {
+      const proposalId = proposal.snapshotProposal?.idInSnapshot;
+      const proposalName = proposal.snapshotProposal?.msg.payload.name || '';
+
+      if (!proposalId) return null;
+
+      return (
+        <ProposalCard
+          key={proposalId}
+          onClick={onProposalClick}
+          proposal={proposal}
+          // @note If the proposal title is not an address it will fall back to a normal, non-truncated string.
+          name={truncateEthAddress(proposalName, 7)}
+        />
+      );
+    });
+  }
+
+  /**
+   * Render
+   */
+
+  // Render loading
+  if (isLoading && !isError) {
+    return (
+      <div className="loader--emjoi-container">
+        <LoaderWithEmoji />
+      </div>
+    );
+  }
+
+  // Render no proposals
+  if (
+    !governanceProposals.length &&
+    !Object.values(filteredProposals).flatMap((p) => p).length &&
+    isLoadingDone
+  ) {
+    return <p className="text-center">No proposals, yet!</p>;
+  }
+
+  // Render error
+  if (isError) {
+    return (
+      <div className="text-center">
+        <ErrorMessageWithDetails
+          error={governanceProposalsError}
+          renderText="Something went wrong while getting the proposals."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid--fluid grid-container">
+      {/* VOTING PROPOSALS */}
+      {votingProposals.length > 0 && (
+        <>
+          <div className="grid__header">{ProposalHeaderNames.VOTING}</div>
+          <div className="grid__cards">
+            {renderProposalCards(votingProposals)}
+          </div>
+        </>
+      )}
+
+      {/* PASSED PROPOSALS */}
+      {passedProposals.length > 0 && (
+        <>
+          <div className="grid__header">{ProposalHeaderNames.PASSED}</div>
+          <div className="grid__cards">
+            {renderProposalCards(passedProposals)}
+          </div>
+        </>
+      )}
+
+      {/* FAILED PROPOSALS */}
+      {failedProposals.length > 0 && (
+        <>
+          <div className="grid__header">{ProposalHeaderNames.FAILED}</div>
+          <div className="grid__cards">
+            {renderProposalCards(failedProposals)}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/governance/GovernanceProposalsList.tsx
+++ b/src/components/governance/GovernanceProposalsList.tsx
@@ -169,6 +169,7 @@ export default function GovernanceProposalsList(
           key={proposalId}
           onClick={onProposalClick}
           proposal={proposal}
+          proposalOnClickId={proposalId}
           // @note If the proposal title is not an address it will fall back to a normal, non-truncated string.
           name={truncateEthAddress(proposalName, 7)}
         />

--- a/src/components/governance/GovernanceProposalsList.unit.test.tsx
+++ b/src/components/governance/GovernanceProposalsList.unit.test.tsx
@@ -228,4 +228,197 @@ describe('GovernanceProposalsList unit tests', () => {
       );
     });
   });
+
+  test('should render no proposals text', async () => {
+    server.use(
+      ...[
+        rest.get(
+          `${SNAPSHOT_HUB_API_URL}/api/:spaceName/proposals/:adapterAddress`,
+          async (_req, res, ctx) => res(ctx.json({}))
+        ),
+      ]
+    );
+
+    render(
+      <Wrapper
+        useInit
+        useWallet
+        getProps={({mockWeb3Provider, web3Instance}) => {
+          /**
+           * Inject voting results. The order should align with the order above of fake responses.
+           */
+
+          // 1. Inject passed result
+          mockWeb3Provider.injectResult(
+            web3Instance.eth.abi.encodeParameters(
+              ['uint256', 'bytes[]'],
+              [
+                0,
+                [
+                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '200000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+                ],
+              ]
+            ),
+            {abi: MulticallABI, abiMethodName: 'aggregate'}
+          );
+
+          // 2. Inject failed result
+          mockWeb3Provider.injectResult(
+            web3Instance.eth.abi.encodeParameters(
+              ['uint256', 'bytes[]'],
+              [
+                0,
+                [
+                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '200000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '300000'),
+                ],
+              ]
+            ),
+            {abi: MulticallABI, abiMethodName: 'aggregate'}
+          );
+
+          // 3. Inject voting result
+          mockWeb3Provider.injectResult(
+            web3Instance.eth.abi.encodeParameters(
+              ['uint256', 'bytes[]'],
+              [
+                0,
+                [
+                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+                ],
+              ]
+            ),
+            {abi: MulticallABI, abiMethodName: 'aggregate'}
+          );
+        }}>
+        <GovernanceProposalsList
+          actionId={BURN_ADDRESS}
+          onProposalClick={() => {}}
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/loading content/i)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/no proposals, yet!/i)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      // Proposal headers
+      expect(() => screen.getByText(/^passed$/i)).toThrow();
+      expect(() => screen.getByText(/^failed$/i)).toThrow();
+      expect(() => screen.getByText(/^voting$/i)).toThrow();
+
+      // Proposal names
+      expect(() => screen.getByText(/another cool one/i)).toThrow();
+      expect(() => screen.getByText(/another rad one/i)).toThrow();
+      expect(() => screen.getByText(/another awesome one/i)).toThrow();
+    });
+  });
+
+  test('should render error', async () => {
+    server.use(
+      ...[
+        rest.get(
+          `${SNAPSHOT_HUB_API_URL}/api/:spaceName/proposals/:adapterAddress`,
+          async (_req, res, ctx) => res(ctx.status(500))
+        ),
+      ]
+    );
+
+    render(
+      <Wrapper
+        useInit
+        useWallet
+        getProps={({mockWeb3Provider, web3Instance}) => {
+          /**
+           * Inject voting results. The order should align with the order above of fake responses.
+           */
+
+          // 1. Inject passed result
+          mockWeb3Provider.injectResult(
+            web3Instance.eth.abi.encodeParameters(
+              ['uint256', 'bytes[]'],
+              [
+                0,
+                [
+                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '200000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+                ],
+              ]
+            ),
+            {abi: MulticallABI, abiMethodName: 'aggregate'}
+          );
+
+          // 2. Inject failed result
+          mockWeb3Provider.injectResult(
+            web3Instance.eth.abi.encodeParameters(
+              ['uint256', 'bytes[]'],
+              [
+                0,
+                [
+                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '200000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '300000'),
+                ],
+              ]
+            ),
+            {abi: MulticallABI, abiMethodName: 'aggregate'}
+          );
+
+          // 3. Inject voting result
+          mockWeb3Provider.injectResult(
+            web3Instance.eth.abi.encodeParameters(
+              ['uint256', 'bytes[]'],
+              [
+                0,
+                [
+                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+                ],
+              ]
+            ),
+            {abi: MulticallABI, abiMethodName: 'aggregate'}
+          );
+        }}>
+        <GovernanceProposalsList
+          actionId={BURN_ADDRESS}
+          onProposalClick={() => {}}
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/something went wrong while getting the proposals/i)
+      ).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/^details$/i)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      // Proposal headers
+      expect(() => screen.getByText(/^proposals$/i)).toThrow();
+      expect(() => screen.getByText(/^passed$/i)).toThrow();
+      expect(() => screen.getByText(/^failed$/i)).toThrow();
+      expect(() => screen.getByText(/^voting$/i)).toThrow();
+
+      // Proposal names
+      expect(() => screen.getByText(/another cool one/i)).toThrow();
+      expect(() => screen.getByText(/another rad one/i)).toThrow();
+      expect(() => screen.getByText(/another awesome one/i)).toThrow();
+    });
+  });
 });

--- a/src/components/governance/GovernanceProposalsList.unit.test.tsx
+++ b/src/components/governance/GovernanceProposalsList.unit.test.tsx
@@ -1,0 +1,231 @@
+import {render, screen, waitFor} from '@testing-library/react';
+import {
+  SnapshotProposalResponseData,
+  SnapshotType,
+} from '@openlaw/snapshot-js-erc712';
+
+import {BURN_ADDRESS} from '../../util/constants';
+import {DEFAULT_ETH_ADDRESS} from '../../test/helpers';
+import {rest, server} from '../../test/server';
+import {SNAPSHOT_HUB_API_URL} from '../../config';
+import {snapshotAPIProposalResponse} from '../../test/restResponses';
+import GovernanceProposalsList from './GovernanceProposalsList';
+import MulticallABI from '../../truffle-contracts/Multicall.json';
+import Wrapper from '../../test/Wrapper';
+import userEvent from '@testing-library/user-event';
+
+describe('GovernanceProposalsList unit tests', () => {
+  const defaultProposalVotes: SnapshotProposalResponseData['votes'] = [
+    {
+      DEFAULT_ETH_ADDRESS: {
+        address: DEFAULT_ETH_ADDRESS,
+        msg: {
+          version: '0.2.0',
+          timestamp: '1614264732',
+          token: '0x8f56682a50becb1df2fb8136954f2062871bc7fc',
+          type: SnapshotType.vote,
+          payload: {
+            choice: 1, // Yes
+            proposalHash:
+              '0x1679cac3f54777f5d9c95efd83beff9f87ac55487311ecacd95827d267a15c4e',
+            metadata: {
+              memberAddress: DEFAULT_ETH_ADDRESS,
+            },
+          },
+        },
+        sig:
+          '0xdbdbf122734b34ed5b10542551636e4250e98f443e35bf5d625f284fe54dcaf80c5bc44be04fefed1e9e5f25a7c13809a5266fcdbdcd0b94c885f2128544e79a1b',
+        authorIpfsHash:
+          '0xfe8f864ef475f60c7e01d5425df332199c5ae7ab712b8545f07433c68f06c644',
+        relayerIpfsHash: '',
+        actionId: '0xFCB86F90bd7b30cDB8A2c43FB15bf5B33A70Ea4f',
+      },
+    },
+    {
+      '0xc0437e11094275376defbe51dc6e04598403d276': {
+        address: '0xc0437e11094275376defbe51dc6e04598403d276',
+        msg: {
+          version: '0.2.0',
+          timestamp: '1614264732',
+          token: '0x8f56682a50becb1df2fb8136954f2062871bc7fc',
+          type: SnapshotType.vote,
+          payload: {
+            choice: 2, // No
+            proposalHash:
+              '0x1679cac3f54777f5d9c95efd83beff9f87ac55487311ecacd95827d267a15c4e',
+            metadata: {
+              memberAddress: '0xc0437e11094275376defbe51dc6e04598403d276',
+            },
+          },
+        },
+        sig:
+          '0xdbdbf122734b34ed5b10542551636e4250e98f443e35bf5d625f284fe54dcaf80c5bc44be04fefed1e9e5f25a7c13809a5266fcdbdcd0b94c885f2128544e79a1b',
+        authorIpfsHash:
+          '0xfe8f864ef475f60c7e01d5425df332199c5ae7ab712b8545f07433c68f06c644',
+        relayerIpfsHash: '',
+        actionId: '0xFCB86F90bd7b30cDB8A2c43FB15bf5B33A70Ea4f',
+      },
+    },
+  ];
+
+  const defaultProposalBody = Object.values(snapshotAPIProposalResponse)[0];
+
+  const proposalsResponse: typeof snapshotAPIProposalResponse = {
+    // Proposal passed
+    '0xb22ca9af120bfddfc2071b5e86a9edee6e0e2ab76399e7c2d96a9d502f5c3333': {
+      ...defaultProposalBody,
+      msg: {
+        ...defaultProposalBody.msg,
+        payload: {
+          ...defaultProposalBody.msg.payload,
+          name: 'Another cool one',
+        },
+      },
+      data: {
+        erc712DraftHash:
+          '0xb22ca9af120bfddfc2071b5e86a9edee6e0e2ab76399e7c2d96a9d502f5c3434',
+        authorIpfsHash: '',
+      },
+      votes: defaultProposalVotes,
+    },
+    // Proposal failed
+    '0xb22ca9af120bfddfc2071b5e86a9edee6e0e2ab76399e7c2d96a9d502f5c4444': {
+      ...defaultProposalBody,
+      msg: {
+        ...defaultProposalBody.msg,
+        payload: {
+          ...defaultProposalBody.msg.payload,
+          name: 'Another rad one',
+        },
+      },
+      data: {
+        erc712DraftHash:
+          '0xb22ca9af120bfddfc2071b5e86a9edee6e0e2ab76399e7c2d96a9d502f5c4545',
+        authorIpfsHash: '',
+      },
+      votes: defaultProposalVotes,
+    },
+    // Proposal voting
+    '0xb22ca9af120bfddfc2071b5e86a9edee6e0e2ab76399e7c2d96a9d502f5c5555': {
+      ...defaultProposalBody,
+      msg: {
+        ...defaultProposalBody.msg,
+        payload: {
+          ...defaultProposalBody.msg.payload,
+          name: 'Another awesome one',
+          start: Date.now() / 1000 - 86400,
+          end: Date.now() / 1000 + 86400,
+        },
+      },
+      data: {
+        erc712DraftHash:
+          '0xb22ca9af120bfddfc2071b5e86a9edee6e0e2ab76399e7c2d96a9d502f5c5656',
+        authorIpfsHash: '',
+      },
+      votes: defaultProposalVotes,
+    },
+  };
+
+  test('should render proposal cards', async () => {
+    const spy = jest.fn();
+
+    server.use(
+      ...[
+        rest.get(
+          `${SNAPSHOT_HUB_API_URL}/api/:spaceName/proposals/:adapterAddress`,
+          async (_req, res, ctx) => res(ctx.json(proposalsResponse))
+        ),
+      ]
+    );
+
+    render(
+      <Wrapper
+        useInit
+        useWallet
+        getProps={({mockWeb3Provider, web3Instance}) => {
+          /**
+           * Inject voting results. The order should align with the order above of fake responses.
+           */
+
+          // 1. Inject passed result
+          mockWeb3Provider.injectResult(
+            web3Instance.eth.abi.encodeParameters(
+              ['uint256', 'bytes[]'],
+              [
+                0,
+                [
+                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '200000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+                ],
+              ]
+            ),
+            {abi: MulticallABI, abiMethodName: 'aggregate'}
+          );
+
+          // 2. Inject failed result
+          mockWeb3Provider.injectResult(
+            web3Instance.eth.abi.encodeParameters(
+              ['uint256', 'bytes[]'],
+              [
+                0,
+                [
+                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '200000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '300000'),
+                ],
+              ]
+            ),
+            {abi: MulticallABI, abiMethodName: 'aggregate'}
+          );
+
+          // 3. Inject voting result
+          mockWeb3Provider.injectResult(
+            web3Instance.eth.abi.encodeParameters(
+              ['uint256', 'bytes[]'],
+              [
+                0,
+                [
+                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+                ],
+              ]
+            ),
+            {abi: MulticallABI, abiMethodName: 'aggregate'}
+          );
+        }}>
+        <GovernanceProposalsList
+          actionId={BURN_ADDRESS}
+          onProposalClick={spy}
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/loading content/i)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      // Proposal headers
+      expect(screen.getByText(/^voting$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^passed$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^failed$/i)).toBeInTheDocument();
+
+      // Proposal names
+      expect(screen.getByText(/^another awesome one$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^another cool one$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^another rad one$/i)).toBeInTheDocument();
+    });
+
+    // Click on a proposal
+    userEvent.click(screen.getByText(/^another awesome one$/i));
+
+    // Expect correct proposal id to come through in function args
+    await waitFor(() => {
+      expect(spy.mock.calls[0][0]).toBe(
+        '0xb22ca9af120bfddfc2071b5e86a9edee6e0e2ab76399e7c2d96a9d502f5c5555'
+      );
+    });
+  });
+});

--- a/src/components/governance/hooks/index.ts
+++ b/src/components/governance/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useGovernanceProposals';

--- a/src/components/governance/hooks/useGovernanceProposals.ts
+++ b/src/components/governance/hooks/useGovernanceProposals.ts
@@ -1,0 +1,134 @@
+import {useCallback, useEffect, useState} from 'react';
+import {
+  SnapshotProposalResponse,
+  SnapshotType,
+} from '@openlaw/snapshot-js-erc712';
+
+import {AsyncStatus} from '../../../util/types';
+import {BURN_ADDRESS} from '../../../util/constants';
+import {ProposalData} from '../../proposals/types';
+import {SNAPSHOT_HUB_API_URL, SPACE} from '../../../config';
+
+type UseGovernanceProposalsReturn = {
+  governanceProposals: ProposalData[];
+  governanceProposalsStatus: AsyncStatus;
+  governanceProposalsError: Error | undefined;
+};
+
+/**
+ * useGovernanceProposals
+ *
+ * Provides an array of id->proposal tuples of governance-style proposals which are not submitted on-chain.
+ *
+ * @param {{actionId : string}}
+ *   - `actionId`: Name of the ERC-712 `actionId` to get Governance proposals by. Defaults to `BURN_ADDRESS`.
+ * @returns `UseGovernanceProposalsReturn` An object with the governance proposals, and the current async status.
+ */
+export function useGovernanceProposals({
+  actionId = BURN_ADDRESS,
+}: {
+  actionId?: string;
+}): UseGovernanceProposalsReturn {
+  /**
+   * State
+   */
+
+  const [governanceProposals, setGovernanceProposals] = useState<
+    ProposalData[]
+  >([]);
+  const [
+    governanceProposalsError,
+    setGovernanceProposalsError,
+  ] = useState<Error>();
+  const [
+    governanceProposalsStatus,
+    setGovernanceProposalsStatus,
+  ] = useState<AsyncStatus>(AsyncStatus.STANDBY);
+
+  /**
+   * Cached callbacks
+   */
+
+  const handleGetProposalsCached = useCallback(handleGetProposals, [actionId]);
+
+  /**
+   * Effects
+   */
+
+  useEffect(() => {
+    handleGetProposalsCached();
+  }, [handleGetProposalsCached]);
+
+  /**
+   * Functions
+   */
+
+  /**
+   * Gets Proposals from Snapshot Hub
+   */
+  async function getSnapshotProposalsByActionId(
+    actionId: string
+  ): Promise<ProposalData[]> {
+    try {
+      const baseURL = `${SNAPSHOT_HUB_API_URL}/api/${SPACE}`;
+
+      const proposals = await fetch(
+        `${baseURL}/proposals/${actionId}?includeVotes=true`
+      );
+
+      if (!proposals.ok) {
+        throw new Error(
+          'Something went wrong while fetching the Snapshot proposals.'
+        );
+      }
+
+      const proposalsJSON: SnapshotProposalResponse = await proposals.json();
+
+      /**
+       * @note The id of the proposal is used and we do not consider any Draft id,
+       *   as we do for Snapshot->on-chain proposals.
+       *
+       * @todo Fix type of return so we don't need to add so many empty key/value pairs.
+       */
+      return Object.entries(proposalsJSON).map(
+        ([id, snapshotProposal]): ProposalData => ({
+          daoProposal: undefined,
+          snapshotDraft: undefined,
+          snapshotProposal: {
+            ...snapshotProposal,
+            idInSnapshot: id,
+            idInDAO: '',
+          },
+          getCommonSnapshotProposalData: () => undefined,
+          refetchProposalOrDraft: () => undefined,
+          snapshotType: SnapshotType.proposal,
+        })
+      );
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async function handleGetProposals() {
+    try {
+      setGovernanceProposalsStatus(AsyncStatus.PENDING);
+
+      const snapshotProposalEntries = await getSnapshotProposalsByActionId(
+        actionId
+      );
+
+      setGovernanceProposalsStatus(AsyncStatus.FULFILLED);
+      setGovernanceProposals(snapshotProposalEntries);
+    } catch (error) {
+      setGovernanceProposalsStatus(AsyncStatus.REJECTED);
+      setGovernanceProposals([]);
+      setGovernanceProposalsError(error);
+    }
+  }
+
+  return {
+    governanceProposals,
+    governanceProposalsError,
+    governanceProposalsStatus,
+  };
+}

--- a/src/components/governance/hooks/useGovernanceProposals.unit.test.ts
+++ b/src/components/governance/hooks/useGovernanceProposals.unit.test.ts
@@ -1,0 +1,96 @@
+import {renderHook, act} from '@testing-library/react-hooks';
+
+import {AsyncStatus} from '../../../util/types';
+import {BURN_ADDRESS} from '../../../util/constants';
+import {rest, server} from '../../../test/server';
+import {SNAPSHOT_HUB_API_URL} from '../../../config';
+import {snapshotAPIProposalResponse} from '../../../test/restResponses';
+import {useGovernanceProposals} from './useGovernanceProposals';
+
+describe('useGovernanceProposals unit tests', () => {
+  test('should return correct data', async () => {
+    await act(async () => {
+      server.use(
+        ...[
+          rest.get(
+            `${SNAPSHOT_HUB_API_URL}/api/:spaceName/proposals/:actionId`,
+            async (_req, res, ctx) => res(ctx.json(snapshotAPIProposalResponse))
+          ),
+        ]
+      );
+
+      const {result, waitForNextUpdate} = await renderHook(() =>
+        useGovernanceProposals({actionId: BURN_ADDRESS})
+      );
+
+      expect(result.current.governanceProposals).toMatchObject([]);
+      expect(result.current.governanceProposalsError).toBe(undefined);
+      expect(result.current.governanceProposalsStatus).toBe(
+        AsyncStatus.STANDBY
+      );
+
+      await waitForNextUpdate();
+
+      expect(result.current.governanceProposals).toMatchObject([]);
+      expect(result.current.governanceProposalsError).toBe(undefined);
+      expect(result.current.governanceProposalsStatus).toBe(
+        AsyncStatus.PENDING
+      );
+
+      await waitForNextUpdate();
+
+      expect(
+        result.current.governanceProposals[0].snapshotProposal
+      ).toMatchObject({
+        ...Object.values(snapshotAPIProposalResponse)[0],
+        idInSnapshot: Object.keys(snapshotAPIProposalResponse)[0],
+        idInDAO: '',
+      });
+      expect(result.current.governanceProposalsError).toBe(undefined);
+      expect(result.current.governanceProposalsStatus).toBe(
+        AsyncStatus.FULFILLED
+      );
+    });
+  });
+
+  test('should return error', async () => {
+    await act(async () => {
+      server.use(
+        ...[
+          rest.get(
+            `${SNAPSHOT_HUB_API_URL}/api/:spaceName/proposals/:actionId`,
+            async (_req, res, ctx) => res(ctx.status(500))
+          ),
+        ]
+      );
+
+      const {result, waitForNextUpdate} = await renderHook(() =>
+        useGovernanceProposals({actionId: BURN_ADDRESS})
+      );
+
+      expect(result.current.governanceProposals).toMatchObject([]);
+      expect(result.current.governanceProposalsError).toBe(undefined);
+      expect(result.current.governanceProposalsStatus).toBe(
+        AsyncStatus.STANDBY
+      );
+
+      await waitForNextUpdate();
+
+      expect(result.current.governanceProposals).toMatchObject([]);
+      expect(result.current.governanceProposalsError).toBe(undefined);
+      expect(result.current.governanceProposalsStatus).toBe(
+        AsyncStatus.PENDING
+      );
+
+      await waitForNextUpdate();
+
+      expect(result.current.governanceProposals).toMatchObject([]);
+      expect(result.current.governanceProposalsError?.message).toMatch(
+        /something went wrong while fetching the Snapshot proposals/i
+      );
+      expect(result.current.governanceProposalsStatus).toBe(
+        AsyncStatus.REJECTED
+      );
+    });
+  });
+});

--- a/src/components/proposals/ProposalCard.tsx
+++ b/src/components/proposals/ProposalCard.tsx
@@ -37,7 +37,11 @@ export default function ProposalCard(props: ProposalCardProps): JSX.Element {
 
   function handleClick() {
     const proposalHash =
-      proposal.snapshotProposal?.idInDAO || proposal.snapshotDraft?.idInDAO;
+      // i.e. Snapshot->DAO proposals
+      proposal.snapshotProposal?.idInDAO ||
+      proposal.snapshotDraft?.idInDAO ||
+      // i.e. Snapshot Governance proposals
+      proposal.snapshotProposal?.idInSnapshot;
 
     proposalHash && onClick(proposalHash);
   }

--- a/src/components/proposals/ProposalCard.tsx
+++ b/src/components/proposals/ProposalCard.tsx
@@ -7,8 +7,14 @@ import {VotingAdapterName} from '../adapters-extensions/enums';
 
 type ProposalCardProps = {
   buttonText?: string;
-  onClick: (proposalHash: string) => void;
+  onClick: (proposalOnClickId: string) => void;
   proposal: ProposalData;
+  /**
+   * The ID for the proposal to be used for navigation.
+   * As there can be a few different options, it's best to provide it
+   * explicitly.
+   */
+  proposalOnClickId: string;
   name: string;
 };
 
@@ -21,7 +27,13 @@ const DEFAULT_BUTTON_TEXT: string = 'View Proposal';
  * @returns {JSX.Element}
  */
 export default function ProposalCard(props: ProposalCardProps): JSX.Element {
-  const {buttonText = DEFAULT_BUTTON_TEXT, proposal, onClick, name} = props;
+  const {
+    buttonText = DEFAULT_BUTTON_TEXT,
+    proposal,
+    proposalOnClickId,
+    onClick,
+    name,
+  } = props;
 
   /**
    * Selectors
@@ -36,14 +48,7 @@ export default function ProposalCard(props: ProposalCardProps): JSX.Element {
    */
 
   function handleClick() {
-    const proposalHash =
-      // i.e. Snapshot->DAO proposals
-      proposal.snapshotProposal?.idInDAO ||
-      proposal.snapshotDraft?.idInDAO ||
-      // i.e. Snapshot Governance proposals
-      proposal.snapshotProposal?.idInSnapshot;
-
-    proposalHash && onClick(proposalHash);
+    onClick(proposalOnClickId);
   }
 
   /**

--- a/src/components/proposals/ProposalCard.unit.test.tsx
+++ b/src/components/proposals/ProposalCard.unit.test.tsx
@@ -41,6 +41,7 @@ describe('ProposalCard unit tests', () => {
         <ProposalCard
           name={name}
           proposal={fakeProposal as ProposalData}
+          proposalOnClickId={fakeProposal.snapshotProposal?.idInDAO as string}
           onClick={() => {}}
         />
       </Wrapper>
@@ -61,6 +62,7 @@ describe('ProposalCard unit tests', () => {
         <ProposalCard
           name={name}
           proposal={fakeProposal as ProposalData}
+          proposalOnClickId={fakeProposal.snapshotProposal?.idInDAO as string}
           onClick={spy}
         />
       </Wrapper>
@@ -87,6 +89,7 @@ describe('ProposalCard unit tests', () => {
           buttonText="Sponsor proposal"
           name={name}
           proposal={fakeProposal as ProposalData}
+          proposalOnClickId={fakeProposal.snapshotProposal?.idInDAO as string}
           onClick={spy}
         />
       </Wrapper>
@@ -110,6 +113,7 @@ describe('ProposalCard unit tests', () => {
           buttonText=""
           name={name}
           proposal={fakeProposal as ProposalData}
+          proposalOnClickId={fakeProposal.snapshotProposal?.idInDAO as string}
           onClick={spy}
         />
       </Wrapper>

--- a/src/components/proposals/Proposals.tsx
+++ b/src/components/proposals/Proposals.tsx
@@ -8,9 +8,9 @@ import {ProposalHeaderNames} from '../../util/enums';
 import {truncateEthAddress} from '../../util/helpers';
 import {useProposals, useProposalsVotingState} from './hooks';
 import {VotingState} from './voting/types';
-import ProposalCard from './ProposalCard';
-import LoaderWithEmoji from '../feedback/LoaderWithEmoji';
 import ErrorMessageWithDetails from '../common/ErrorMessageWithDetails';
+import LoaderWithEmoji from '../feedback/LoaderWithEmoji';
+import ProposalCard from './ProposalCard';
 
 type ProposalsProps = {
   adapterName: DaoAdapterConstants;
@@ -67,12 +67,12 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
   } = filteredProposals;
 
   const isLoading: boolean =
+    proposalsStatus === AsyncStatus.STANDBY ||
     proposalsStatus === AsyncStatus.PENDING ||
+    // Getting ready to fetch using `useProposalsVotingState`; helps to show continuous loader.
+    (proposalsVotingStateStatus === AsyncStatus.STANDBY &&
+      proposalIds.length > 0) ||
     proposalsVotingStateStatus === AsyncStatus.PENDING;
-
-  const isLoadingDone: boolean =
-    proposalsStatus === AsyncStatus.FULFILLED ||
-    proposalsVotingStateStatus === AsyncStatus.FULFILLED;
 
   const isError: boolean =
     proposalsStatus === AsyncStatus.REJECTED ||
@@ -119,6 +119,8 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
         proposalHasFlag(ProposalFlag.EXISTS, p.daoProposal.flags)
       ) {
         filteredProposalsToSet.nonsponsoredProposals.push(p);
+
+        return;
       }
 
       // voting proposal
@@ -128,6 +130,8 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
         proposalHasFlag(ProposalFlag.SPONSORED, p.daoProposal.flags)
       ) {
         filteredProposalsToSet.votingProposals.push(p);
+
+        return;
       }
 
       // passed proposal
@@ -137,6 +141,8 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
           proposalHasFlag(ProposalFlag.PROCESSED, p.daoProposal.flags))
       ) {
         filteredProposalsToSet.passedProposals.push(p);
+
+        return;
       }
 
       // failed proposal
@@ -147,6 +153,8 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
           proposalHasFlag(ProposalFlag.PROCESSED, p.daoProposal.flags))
       ) {
         filteredProposalsToSet.failedProposals.push(p);
+
+        return;
       }
     });
 
@@ -207,7 +215,7 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
   if (
     !Object.values(proposals).length &&
     !Object.values(filteredProposals).flatMap((p) => p).length &&
-    isLoadingDone
+    proposalsStatus === AsyncStatus.FULFILLED
   ) {
     return <p className="text-center">No proposals, yet!</p>;
   }

--- a/src/components/proposals/Proposals.tsx
+++ b/src/components/proposals/Proposals.tsx
@@ -191,6 +191,7 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
           key={proposalId}
           onClick={onProposalClick}
           proposal={proposal}
+          proposalOnClickId={proposalId}
           // @note If the proposal title is not an address it will fall back to a normal, non-truncated string.
           name={truncateEthAddress(proposalName, 7)}
         />

--- a/src/components/proposals/hooks/useOffchainVotingResults.unit.test.ts
+++ b/src/components/proposals/hooks/useOffchainVotingResults.unit.test.ts
@@ -1,104 +1,116 @@
 import {SnapshotType} from '@openlaw/snapshot-js-erc712';
 import {renderHook, act} from '@testing-library/react-hooks';
 
-import {DEFAULT_ETH_ADDRESS} from '../../../test/helpers';
-import {ProposalData} from '../types';
+import {
+  DEFAULT_ETH_ADDRESS,
+  DEFAULT_PROPOSAL_HASH,
+} from '../../../test/helpers';
+import {SnapshotProposal} from '../types';
 import {useOffchainVotingResults} from './useOffchainVotingResults';
 import {VoteChoices} from '../../web3/types';
 import MulticallABI from '../../../truffle-contracts/Multicall.json';
 import Wrapper from '../../../test/Wrapper';
 
+const fakeSnapshotProposal: SnapshotProposal = {
+  msg: {
+    payload: {
+      snapshot: 123,
+      name: '',
+      body: '',
+      choices: [VoteChoices.Yes, VoteChoices.No],
+      metadata: {},
+      start: 0,
+      end: 0,
+    },
+    version: '',
+    timestamp: '',
+    token: '',
+    type: SnapshotType.proposal,
+  },
+  actionId: '',
+  address: '',
+  authorIpfsHash: '',
+  data: {authorIpfsHash: ''},
+  idInDAO: DEFAULT_PROPOSAL_HASH,
+  idInSnapshot: DEFAULT_PROPOSAL_HASH,
+  relayerIpfsHash: '',
+  sig: '',
+  votes: [
+    {
+      DEFAULT_ETH_ADDRESS: {
+        address: DEFAULT_ETH_ADDRESS,
+        msg: {
+          version: '0.2.0',
+          timestamp: '1614264732',
+          token: '0x8f56682a50becb1df2fb8136954f2062871bc7fc',
+          type: SnapshotType.vote,
+          payload: {
+            choice: 1, // Yes
+            proposalHash:
+              '0x1679cac3f54777f5d9c95efd83beff9f87ac55487311ecacd95827d267a15c4e',
+            metadata: {
+              memberAddress: DEFAULT_ETH_ADDRESS,
+            },
+          },
+        },
+        sig:
+          '0xdbdbf122734b34ed5b10542551636e4250e98f443e35bf5d625f284fe54dcaf80c5bc44be04fefed1e9e5f25a7c13809a5266fcdbdcd0b94c885f2128544e79a1b',
+        authorIpfsHash:
+          '0xfe8f864ef475f60c7e01d5425df332199c5ae7ab712b8545f07433c68f06c644',
+        relayerIpfsHash: '',
+        actionId: '0xFCB86F90bd7b30cDB8A2c43FB15bf5B33A70Ea4f',
+      },
+    },
+    {
+      '0xc0437e11094275376defbe51dc6e04598403d276': {
+        address: '0xc0437e11094275376defbe51dc6e04598403d276',
+        msg: {
+          version: '0.2.0',
+          timestamp: '1614264732',
+          token: '0x8f56682a50becb1df2fb8136954f2062871bc7fc',
+          type: SnapshotType.vote,
+          payload: {
+            choice: 2, // No
+            proposalHash:
+              '0x1679cac3f54777f5d9c95efd83beff9f87ac55487311ecacd95827d267a15c4e',
+            metadata: {
+              memberAddress: '0xc0437e11094275376defbe51dc6e04598403d276',
+            },
+          },
+        },
+        sig:
+          '0xdbdbf122734b34ed5b10542551636e4250e98f443e35bf5d625f284fe54dcaf80c5bc44be04fefed1e9e5f25a7c13809a5266fcdbdcd0b94c885f2128544e79a1b',
+        authorIpfsHash:
+          '0xfe8f864ef475f60c7e01d5425df332199c5ae7ab712b8545f07433c68f06c644',
+        relayerIpfsHash: '',
+        actionId: '0xFCB86F90bd7b30cDB8A2c43FB15bf5B33A70Ea4f',
+      },
+    },
+  ],
+};
+
 describe('useOffchainVotingResults unit tests', () => {
   test('should return correct data', async () => {
-    // @note Providing only data required (by the hook and just enough for TS).
-    const fakeProposal: Partial<ProposalData> = {
-      snapshotProposal: {
-        msg: {
-          payload: {
-            snapshot: 123,
-            name: '',
-            body: '',
-            choices: [VoteChoices.Yes, VoteChoices.No],
-            metadata: {},
-            start: 0,
-            end: 0,
-          },
-          version: '',
-          timestamp: '',
-          token: '',
-          type: SnapshotType.proposal,
-        },
-        actionId: '',
-        address: '',
-        authorIpfsHash: '',
-        data: {authorIpfsHash: ''},
-        idInDAO: '',
-        idInSnapshot: '',
-        relayerIpfsHash: '',
-        sig: '',
-        votes: [
-          {
-            DEFAULT_ETH_ADDRESS: {
-              address: DEFAULT_ETH_ADDRESS,
-              msg: {
-                version: '0.2.0',
-                timestamp: '1614264732',
-                token: '0x8f56682a50becb1df2fb8136954f2062871bc7fc',
-                type: SnapshotType.vote,
-                payload: {
-                  choice: 1, // Yes
-                  proposalHash:
-                    '0x1679cac3f54777f5d9c95efd83beff9f87ac55487311ecacd95827d267a15c4e',
-                  metadata: {
-                    memberAddress: DEFAULT_ETH_ADDRESS,
-                  },
-                },
-              },
-              sig:
-                '0xdbdbf122734b34ed5b10542551636e4250e98f443e35bf5d625f284fe54dcaf80c5bc44be04fefed1e9e5f25a7c13809a5266fcdbdcd0b94c885f2128544e79a1b',
-              authorIpfsHash:
-                '0xfe8f864ef475f60c7e01d5425df332199c5ae7ab712b8545f07433c68f06c644',
-              relayerIpfsHash: '',
-              actionId: '0xFCB86F90bd7b30cDB8A2c43FB15bf5B33A70Ea4f',
-            },
-          },
-          {
-            '0xc0437e11094275376defbe51dc6e04598403d276': {
-              address: '0xc0437e11094275376defbe51dc6e04598403d276',
-              msg: {
-                version: '0.2.0',
-                timestamp: '1614264732',
-                token: '0x8f56682a50becb1df2fb8136954f2062871bc7fc',
-                type: SnapshotType.vote,
-                payload: {
-                  choice: 2, // No
-                  proposalHash:
-                    '0x1679cac3f54777f5d9c95efd83beff9f87ac55487311ecacd95827d267a15c4e',
-                  metadata: {
-                    memberAddress: '0xc0437e11094275376defbe51dc6e04598403d276',
-                  },
-                },
-              },
-              sig:
-                '0xdbdbf122734b34ed5b10542551636e4250e98f443e35bf5d625f284fe54dcaf80c5bc44be04fefed1e9e5f25a7c13809a5266fcdbdcd0b94c885f2128544e79a1b',
-              authorIpfsHash:
-                '0xfe8f864ef475f60c7e01d5425df332199c5ae7ab712b8545f07433c68f06c644',
-              relayerIpfsHash: '',
-              actionId: '0xFCB86F90bd7b30cDB8A2c43FB15bf5B33A70Ea4f',
-            },
-          },
-        ],
+    const someRandomHash =
+      '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+    const fakeSnapshotProposals: SnapshotProposal[] = [
+      fakeSnapshotProposal,
+      {
+        ...fakeSnapshotProposal,
+        idInDAO: someRandomHash,
+        idInSnapshot: someRandomHash,
       },
-    };
+    ];
 
     await act(async () => {
       const {result, waitForNextUpdate} = await renderHook(
-        () => useOffchainVotingResults(fakeProposal as ProposalData),
+        () => useOffchainVotingResults(fakeSnapshotProposals),
         {
           wrapper: Wrapper,
           initialProps: {
             getProps: ({mockWeb3Provider, web3Instance}) => {
-              // Inject mocked result
+              // Inject mocked shares result 1
               mockWeb3Provider.injectResult(
                 web3Instance.eth.abi.encodeParameters(
                   ['uint256', 'bytes[]'],
@@ -116,6 +128,25 @@ describe('useOffchainVotingResults unit tests', () => {
                 ),
                 {abi: MulticallABI, abiMethodName: 'aggregate'}
               );
+
+              // Inject mocked shares result 2
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      web3Instance.eth.abi.encodeParameter(
+                        'uint256',
+                        '20000000'
+                      ),
+                      web3Instance.eth.abi.encodeParameter('uint256', '400000'),
+                      web3Instance.eth.abi.encodeParameter('uint256', '200000'),
+                    ],
+                  ]
+                ),
+                {abi: MulticallABI, abiMethodName: 'aggregate'}
+              );
             },
             useInit: true,
             useWallet: true,
@@ -125,13 +156,37 @@ describe('useOffchainVotingResults unit tests', () => {
 
       await waitForNextUpdate();
       await waitForNextUpdate();
-      await waitForNextUpdate();
 
-      expect(result.current?.Yes).toMatchObject({
-        percentage: 2,
-        shares: 200000,
-      });
-      expect(result.current?.No).toMatchObject({percentage: 1, shares: 100000});
+      expect(result.current).toMatchObject([
+        [
+          DEFAULT_PROPOSAL_HASH,
+          {
+            No: {
+              percentage: 1,
+              shares: 100000,
+            },
+            Yes: {
+              percentage: 2,
+              shares: 200000,
+            },
+            totalShares: 10000000,
+          },
+        ],
+        [
+          someRandomHash,
+          {
+            No: {
+              percentage: 1,
+              shares: 200000,
+            },
+            Yes: {
+              percentage: 2,
+              shares: 400000,
+            },
+            totalShares: 20000000,
+          },
+        ],
+      ]);
     });
   });
 });

--- a/src/components/proposals/hooks/useOffchainVotingResults.unit.test.ts
+++ b/src/components/proposals/hooks/useOffchainVotingResults.unit.test.ts
@@ -154,39 +154,52 @@ describe('useOffchainVotingResults unit tests', () => {
         }
       );
 
-      await waitForNextUpdate();
+      expect(result.current).toMatchObject({
+        offchainVotingResults: [],
+        offchainVotingResultsError: undefined,
+        offchainVotingResultsStatus: 'STANDBY',
+      });
+
       await waitForNextUpdate();
 
-      expect(result.current).toMatchObject([
-        [
-          DEFAULT_PROPOSAL_HASH,
-          {
-            No: {
-              percentage: 1,
-              shares: 100000,
+      expect(result.current).toMatchObject({
+        offchainVotingResults: [],
+        offchainVotingResultsError: undefined,
+        offchainVotingResultsStatus: 'STANDBY',
+      });
+
+      await waitForNextUpdate();
+
+      expect(result.current).toMatchObject({
+        offchainVotingResults: [],
+        offchainVotingResultsError: undefined,
+        offchainVotingResultsStatus: 'PENDING',
+      });
+
+      await waitForNextUpdate();
+
+      expect(result.current).toMatchObject({
+        offchainVotingResults: [
+          [
+            '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+            {
+              No: {percentage: 1, shares: 100000},
+              Yes: {percentage: 2, shares: 200000},
+              totalShares: 10000000,
             },
-            Yes: {
-              percentage: 2,
-              shares: 200000,
+          ],
+          [
+            '0x0000000000000000000000000000000000000000000000000000000000000000',
+            {
+              No: {percentage: 1, shares: 200000},
+              Yes: {percentage: 2, shares: 400000},
+              totalShares: 20000000,
             },
-            totalShares: 10000000,
-          },
+          ],
         ],
-        [
-          someRandomHash,
-          {
-            No: {
-              percentage: 1,
-              shares: 200000,
-            },
-            Yes: {
-              percentage: 2,
-              shares: 400000,
-            },
-            totalShares: 20000000,
-          },
-        ],
-      ]);
+        offchainVotingResultsError: undefined,
+        offchainVotingResultsStatus: 'FULFILLED',
+      });
     });
   });
 });

--- a/src/components/proposals/hooks/useProposals.ts
+++ b/src/components/proposals/hooks/useProposals.ts
@@ -109,6 +109,12 @@ export function useProposals({
 
       const drafts = await fetch(`${baseURL}/drafts/${adapterAddress}`);
 
+      if (!drafts.ok) {
+        throw new Error(
+          'Something went wrong while fetching the Snapshot drafts.'
+        );
+      }
+
       const draftsJSON: SnapshotDraftResponse = await drafts.json();
 
       // Get Drafts which have not yet been sponsored (Proposal created)
@@ -130,6 +136,12 @@ export function useProposals({
       const proposals = await fetch(
         `${baseURL}/proposals/${adapterAddress}?includeVotes=true`
       );
+
+      if (!proposals.ok) {
+        throw new Error(
+          'Something went wrong while fetching the Snapshot proposals.'
+        );
+      }
 
       const proposalsJSON: SnapshotProposalResponse = await proposals.json();
 

--- a/src/components/proposals/hooks/useProposals.unit.test.ts
+++ b/src/components/proposals/hooks/useProposals.unit.test.ts
@@ -167,4 +167,137 @@ describe('useProposals unit tests', () => {
       );
     });
   });
+
+  test('should return error', async () => {
+    await act(async () => {
+      server.use(
+        ...[
+          rest.get(
+            `${SNAPSHOT_HUB_API_URL}/api/:spaceName/drafts/:adapterAddress`,
+            async (_req, res, ctx) => res(ctx.status(500))
+          ),
+          rest.get(
+            `${SNAPSHOT_HUB_API_URL}/api/:spaceName/proposals/:adapterAddress`,
+            async (_req, res, ctx) => res(ctx.status(500))
+          ),
+        ]
+      );
+
+      const {result, waitForNextUpdate} = await renderHook(
+        () => useProposals({adapterName: DaoAdapterConstants.ONBOARDING}),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useWallet: true,
+            useInit: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              // Mock the proposals' multicall response
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Proposal: {
+                            adapterAddress: 'address',
+                            flags: 'uint256',
+                          },
+                        },
+                        {
+                          adapterAddress: DEFAULT_ETH_ADDRESS,
+                          // ProposalFlag.SPONSORED
+                          flags: '3',
+                        }
+                      ),
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Proposal: {
+                            adapterAddress: 'address',
+                            flags: 'uint256',
+                          },
+                        },
+                        {
+                          adapterAddress: DEFAULT_ETH_ADDRESS,
+                          // ProposalFlag.EXISTS
+                          flags: '1',
+                        }
+                      ),
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      expect(result.current.proposals).toMatchObject([]);
+      expect(result.current.proposalsError).toBe(undefined);
+      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposals).toMatchObject([]);
+      expect(result.current.proposalsError).toBe(undefined);
+      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposals).toMatchObject([]);
+      expect(result.current.proposalsError).toBe(undefined);
+      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposals).toMatchObject([]);
+      expect(result.current.proposalsError).toBe(undefined);
+      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposals).toMatchObject([]);
+      expect(result.current.proposalsError).toBe(undefined);
+      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposals).toMatchObject([]);
+      expect(result.current.proposalsError).toBe(undefined);
+      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposals).toMatchObject([]);
+      expect(result.current.proposalsError).toBe(undefined);
+      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposals).toMatchObject([]);
+      expect(result.current.proposalsError).toBe(undefined);
+      expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposals).toMatchObject([]);
+      expect(result.current.proposalsError).toBe(undefined);
+      expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposals).toMatchObject([]);
+      expect(result.current.proposalsError).toBe(undefined);
+      expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposalsStatus).toBe(AsyncStatus.REJECTED);
+      expect(result.current.proposalsError?.message).toMatch(
+        /something went wrong while fetching the/i
+      );
+      expect(result.current.proposals.length).toBe(0);
+    });
+  });
 });

--- a/src/components/proposals/voting/OffchainVotingStatus.tsx
+++ b/src/components/proposals/voting/OffchainVotingStatus.tsx
@@ -1,4 +1,5 @@
 import {useEffect, useState} from 'react';
+import {useSelector} from 'react-redux';
 
 import {ContractDAOConfigKeys} from '../../web3/types';
 import {CycleEllipsis} from '../../feedback';
@@ -6,7 +7,6 @@ import {getDAOConfigEntry} from '../../web3/helpers';
 import {ProposalData} from '../types';
 import {StoreState} from '../../../store/types';
 import {useOffchainVotingResults, useOffchainVotingStartEnd} from '../hooks';
-import {useSelector} from 'react-redux';
 import {VotingStatus} from './VotingStatus';
 
 type OffchainVotingStatusProps = {
@@ -80,17 +80,21 @@ export function OffchainVotingStatus({
     offchainVotingStartEndInitReady,
   } = useOffchainVotingStartEnd(proposal);
 
-  const votingResults = useOffchainVotingResults(proposal);
+  const {offchainVotingResults} = useOffchainVotingResults(
+    proposal.snapshotProposal
+  );
 
   /**
    * Variables
    */
 
+  // There is only one vote result entry as we only passed a single proposal
+  const votingResult = offchainVotingResults[0]?.[1];
   const votingStartSeconds = snapshotProposal?.msg.payload.start || 0;
   const votingEndSeconds = snapshotProposal?.msg.payload.end || 0;
-  const yesShares = votingResults?.Yes.shares || 0;
-  const noShares = votingResults?.No.shares || 0;
-  const totalShares = votingResults?.totalShares;
+  const yesShares = votingResult?.Yes.shares || 0;
+  const noShares = votingResult?.No.shares || 0;
+  const totalShares = votingResult?.totalShares;
 
   /**
    * Effects

--- a/src/pages/governance/GovernanceProposals.tsx
+++ b/src/pages/governance/GovernanceProposals.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import {useHistory} from 'react-router-dom';
 
-import Wrap from '../../components/common/Wrap';
+import {BURN_ADDRESS} from '../../util/constants';
 import FadeIn from '../../components/common/FadeIn';
+import GovernanceProposalsList from '../../components/governance/GovernanceProposalsList';
+import Wrap from '../../components/common/Wrap';
 
 export default function GovernanceProposals() {
   /**
@@ -11,7 +13,10 @@ export default function GovernanceProposals() {
 
   return (
     <RenderWrapper>
-      <div>GovernanceProposals @todo</div>
+      <GovernanceProposalsList
+        actionId={BURN_ADDRESS}
+        onProposalClick={() => {}}
+      />
     </RenderWrapper>
   );
 }


### PR DESCRIPTION
Fixes #199 

🥳 **Adds**

 - `useGovernanceProposals` + unit tests
 - `GovernanceProposalsList` component  + unit tests

✨ **Updates**

 - `GovernanceProposals` now uses `GovernanceProposalsList`
 - `ProposalCard` now takes a `proposalOnClickId: string` prop; updates unit tests
 - `Proposals` now passes `proposalOnClickId` to `ProposalCard`s
 - `Proposals` UI loading is now smoother
 - `useOffchainVotingResults` now accepts an array of proposals to get results for; updates unit test
 - Improves error handling in `useProposals`; adds unit test
 - `OffchainVotingStatus` now handles new result array entries of updated `useOffchainVotingResults`
