### PR TITLE
Allows passing of voting result from ProposalCard->voting status components

### DIFF
--- a/src/components/feedback/CycleEllipsis.tsx
+++ b/src/components/feedback/CycleEllipsis.tsx
@@ -2,6 +2,7 @@ import React, {useState, useEffect, CSSProperties} from 'react';
 import FadeIn from '../common/FadeIn';
 
 type CycleEllipsisProps = {
+  ariaLabel?: string;
   /**
    * What is the interval of cycling the message?
    */
@@ -20,7 +21,7 @@ const nbspStyles = {
 } as CSSProperties;
 
 export function CycleEllipsis(props: CycleEllipsisProps) {
-  const {intervalMs = 1000, fadeInProps} = props;
+  const {ariaLabel, intervalMs = 1000, fadeInProps} = props;
   const fadeInPropsMerged = {...fadeInProps, inline: true};
 
   const [upToIndex, setUpToIndex] = useState<number>(1);
@@ -38,7 +39,7 @@ export function CycleEllipsis(props: CycleEllipsisProps) {
 
   return (
     <>
-      <span style={rootStyles}>
+      <span aria-label={ariaLabel} style={rootStyles}>
         <span>{upToIndex >= 0 && MESSAGES[0]}</span>
         <span>
           {upToIndex >= 1 && (

--- a/src/components/governance/GovernanceProposalsList.tsx
+++ b/src/components/governance/GovernanceProposalsList.tsx
@@ -115,7 +115,8 @@ export default function GovernanceProposalsList(
 
       const offchainResult = offchainVotingResults.find(
         ([proposalHash, _result]) =>
-          normalizeString(proposalHash) === p.snapshotProposal?.idInSnapshot
+          normalizeString(proposalHash) ===
+          normalizeString(p.snapshotProposal?.idInSnapshot || '')
       )?.[1];
 
       if (!offchainResult) return;
@@ -160,13 +161,19 @@ export default function GovernanceProposalsList(
 
       if (!proposalId) return null;
 
+      const offchainResult = offchainVotingResults.find(
+        ([proposalHash, _result]) =>
+          normalizeString(proposalHash) === normalizeString(proposalId)
+      )?.[1];
+
       return (
         <ProposalCard
           key={proposalId}
+          name={proposalName}
           onClick={onProposalClick}
           proposal={proposal}
           proposalOnClickId={proposalId}
-          name={proposalName}
+          votingResult={offchainResult}
         />
       );
     });

--- a/src/components/governance/GovernanceProposalsList.tsx
+++ b/src/components/governance/GovernanceProposalsList.tsx
@@ -1,15 +1,12 @@
 import React, {useEffect, useState} from 'react';
 
-import {
-  OffchainVotingResult,
-  useOffchainVotingResults,
-} from '../proposals/hooks';
 import {AsyncStatus} from '../../util/types';
 import {BURN_ADDRESS} from '../../util/constants';
 import {normalizeString} from '../../util/helpers';
-import {ProposalData} from '../proposals/types';
+import {ProposalData, VotingResult} from '../proposals/types';
 import {ProposalHeaderNames} from '../../util/enums';
 import {useGovernanceProposals} from './hooks';
+import {useOffchainVotingResults} from '../proposals/hooks';
 import ErrorMessageWithDetails from '../common/ErrorMessageWithDetails';
 import LoaderWithEmoji from '../feedback/LoaderWithEmoji';
 import ProposalCard from '../proposals/ProposalCard';
@@ -28,7 +25,7 @@ type FilteredProposals = {
   votingProposals: ProposalData[];
 };
 
-// @todo Pass `OffchainVotingResult` down to `OffchainVotingStatus` via `ProposalCard`
+// @todo Pass `VotingResult` down to `OffchainVotingStatus` via `ProposalCard`
 export default function GovernanceProposalsList(
   props: GovernanceProposalsListProps
 ): JSX.Element {
@@ -150,9 +147,7 @@ export default function GovernanceProposalsList(
    * Functions
    */
 
-  function didPassSimpleMajority(
-    offchainVoteResult: OffchainVotingResult
-  ): boolean {
+  function didPassSimpleMajority(offchainVoteResult: VotingResult): boolean {
     return offchainVoteResult.Yes.shares > offchainVoteResult.No.shares;
   }
 

--- a/src/components/proposals/ProposalCard.tsx
+++ b/src/components/proposals/ProposalCard.tsx
@@ -3,7 +3,7 @@ import LinesEllipsis from 'react-lines-ellipsis';
 import responsiveHOC from 'react-lines-ellipsis/lib/responsiveHOC';
 
 import {OffchainVotingStatus} from './voting';
-import {ProposalData} from './types';
+import {ProposalData, VotingResult} from './types';
 import {StoreState} from '../../store/types';
 import {VotingAdapterName} from '../adapters-extensions/enums';
 import {isEthAddressValid} from '../../util/validation';
@@ -20,6 +20,14 @@ type ProposalCardProps = {
    */
   proposalOnClickId: string;
   name: string;
+  /**
+   * If a fetched `VotingResult` is provided
+   * it will save the need to fetch inside of `OffchainVotingStatus`.
+   *
+   * e.g. Governance proposals listing may fetch all voting results
+   *   in order to filter the `ProposalCard`s and be able to provide the results.
+   */
+  votingResult?: VotingResult;
 };
 
 const DEFAULT_BUTTON_TEXT: string = 'View Proposal';
@@ -39,6 +47,7 @@ export default function ProposalCard(props: ProposalCardProps): JSX.Element {
     proposalOnClickId,
     onClick,
     name,
+    votingResult,
   } = props;
 
   /**
@@ -66,7 +75,12 @@ export default function ProposalCard(props: ProposalCardProps): JSX.Element {
   function renderStatus(proposal: ProposalData) {
     switch (votingAdapterName) {
       case VotingAdapterName.OffchainVotingContract:
-        return <OffchainVotingStatus proposal={proposal} />;
+        return (
+          <OffchainVotingStatus
+            proposal={proposal}
+            votingResult={votingResult}
+          />
+        );
       // @todo On-chain Voting
       // case VotingAdapterName.VotingContract:
       //   return <></>

--- a/src/components/proposals/hooks/useOffchainVotingResults.ts
+++ b/src/components/proposals/hooks/useOffchainVotingResults.ts
@@ -7,25 +7,14 @@ import Web3 from 'web3';
 import {AsyncStatus} from '../../../util/types';
 import {multicall, MulticallTuple} from '../../web3/helpers';
 import {SHARES_ADDRESS, TOTAL_ADDRESS} from '../../../config';
-import {SnapshotProposal} from '../types';
+import {SnapshotProposal, VotingResult} from '../types';
 import {StoreState} from '../../../store/types';
 import {useWeb3Modal} from '../../web3/hooks';
 import {VoteChoices} from '../../web3/types';
 
-type VoteChoiceResult = {
-  percentage: number;
-  shares: number;
-};
-
-export type OffchainVotingResult = {
-  [VoteChoices.Yes]: VoteChoiceResult;
-  [VoteChoices.No]: VoteChoiceResult;
-  totalShares: number;
-};
-
 type OffchainVotingResultEntries = [
   proposalHash: string,
-  votingResult: OffchainVotingResult
+  votingResult: VotingResult
 ][];
 
 type UseOffchainVotingResultsReturn = {
@@ -183,7 +172,7 @@ export function useOffchainVotingResults(
     snapshot: number;
     voterAddressesAndChoices: [string, number][];
     web3Instance: Web3;
-  }): Promise<OffchainVotingResult> {
+  }): Promise<VotingResult> {
     try {
       // Create results object to set later
       const results = {

--- a/src/components/proposals/types.ts
+++ b/src/components/proposals/types.ts
@@ -4,6 +4,7 @@ import {
   SnapshotDraftResponseData,
   SnapshotProposalResponseData,
   SnapshotType,
+  VoteChoices,
 } from '@openlaw/snapshot-js-erc712';
 
 /**
@@ -136,3 +137,21 @@ export type ProposalOrDraftSnapshotType =
 export type ProposalOrDraftSignDataFromType<
   T extends ProposalOrDraftSnapshotType
 > = T extends SnapshotType.proposal ? SnapshotProposalData : SnapshotDraftData;
+
+/**
+ * VotingResult
+ *
+ * A custom result we build to deliver to components.
+ * It should accommodate all types of yes/no voting (i.e. on-chain, off-chain).
+ */
+
+export type VoteChoiceResult = {
+  percentage: number;
+  shares: number;
+};
+
+export type VotingResult = {
+  [VoteChoices.Yes]: VoteChoiceResult;
+  [VoteChoices.No]: VoteChoiceResult;
+  totalShares: number;
+};

--- a/src/components/proposals/voting/OffchainVotingStatus.tsx
+++ b/src/components/proposals/voting/OffchainVotingStatus.tsx
@@ -24,7 +24,7 @@ type OffchainVotingStatusProps = {
    * it will save the need to fetch inside of this component.
    *
    * e.g. Governance proposals listing may fetch all voting results
-   *   in order to filter the `ProposalCard`s.
+   *   in order to filter the `ProposalCard`s and be able to provide the results.
    */
   votingResult?: VotingResult;
 };

--- a/src/components/proposals/voting/OffchainVotingStatus.tsx
+++ b/src/components/proposals/voting/OffchainVotingStatus.tsx
@@ -18,7 +18,6 @@ type OffchainVotingStatusProps = {
    */
   countdownGracePeriodStartMs?: number;
   proposal: ProposalData;
-  showPercentages?: boolean;
   /**
    * If a fetched `VotingResult` is provided
    * it will save the need to fetch inside of this component.

--- a/src/components/proposals/voting/OffchainVotingStatus.unit.test.tsx
+++ b/src/components/proposals/voting/OffchainVotingStatus.unit.test.tsx
@@ -1,0 +1,200 @@
+import {SnapshotType, VoteChoices} from '@openlaw/snapshot-js-erc712';
+import {render, screen, waitFor} from '@testing-library/react';
+
+import {DEFAULT_ETH_ADDRESS} from '../../../test/helpers';
+import {OffchainVotingStatus} from './OffchainVotingStatus';
+import {ProposalData} from '../types';
+import MulticallABI from '../../../truffle-contracts/Multicall.json';
+import Wrapper from '../../../test/Wrapper';
+
+describe('OffchainVotingStatus unit tests', () => {
+  const yesterday = Date.now() / 1000 - 86400;
+  const now = Date.now() / 1000;
+
+  // Bare minimum fake data
+  const fakeProposal: Partial<ProposalData> = {
+    snapshotDraft: undefined,
+    snapshotProposal: {
+      idInSnapshot: 'abc123',
+      idInDAO: 'abc123',
+      msg: {
+        payload: {
+          name: 'Such a great proposal',
+          body: '',
+          choices: [VoteChoices.Yes, VoteChoices.No],
+          start: yesterday,
+          end: now - 40000,
+          snapshot: 100,
+        },
+        type: SnapshotType.proposal,
+      },
+      votes: [
+        {
+          DEFAULT_ETH_ADDRESS: {
+            address: DEFAULT_ETH_ADDRESS,
+            msg: {
+              version: '0.2.0',
+              timestamp: '1614264732',
+              token: '0x8f56682a50becb1df2fb8136954f2062871bc7fc',
+              type: SnapshotType.vote,
+              payload: {
+                choice: 1, // Yes
+                proposalHash:
+                  '0x1679cac3f54777f5d9c95efd83beff9f87ac55487311ecacd95827d267a15c4e',
+                metadata: {
+                  memberAddress: DEFAULT_ETH_ADDRESS,
+                },
+              },
+            },
+            sig:
+              '0xdbdbf122734b34ed5b10542551636e4250e98f443e35bf5d625f284fe54dcaf80c5bc44be04fefed1e9e5f25a7c13809a5266fcdbdcd0b94c885f2128544e79a1b',
+            authorIpfsHash:
+              '0xfe8f864ef475f60c7e01d5425df332199c5ae7ab712b8545f07433c68f06c644',
+            relayerIpfsHash: '',
+            actionId: '0xFCB86F90bd7b30cDB8A2c43FB15bf5B33A70Ea4f',
+          },
+        },
+      ],
+    } as any,
+  };
+
+  test('should render correct content', async () => {
+    render(
+      <Wrapper
+        useInit
+        useWallet
+        getProps={({mockWeb3Provider, web3Instance}) => {
+          // Inject mocked shares result 1
+          mockWeb3Provider.injectResult(
+            web3Instance.eth.abi.encodeParameters(
+              ['uint256', 'bytes[]'],
+              [
+                0,
+                [
+                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+                ],
+              ]
+            ),
+            {abi: MulticallABI, abiMethodName: 'aggregate'}
+          );
+        }}>
+        <OffchainVotingStatus proposal={fakeProposal as ProposalData} />
+      </Wrapper>
+    );
+
+    // Percentages
+    await waitFor(() => {
+      expect(screen.getByText(/1%/i)).toBeInTheDocument();
+      expect(screen.getByText(/0%/i)).toBeInTheDocument();
+    });
+
+    // Status: loader
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/getting off-chain voting status/i)
+      ).toBeInTheDocument();
+    });
+
+    // Status
+    await waitFor(() => {
+      expect(screen.getByText(/approved/i)).toBeInTheDocument();
+    });
+  });
+
+  test('should render correct content when providing a "votingResult"', async () => {
+    render(
+      <Wrapper useInit useWallet>
+        <OffchainVotingStatus
+          proposal={fakeProposal as ProposalData}
+          votingResult={{
+            Yes: {shares: 100000, percentage: 1},
+            No: {shares: 0, percentage: 0},
+            totalShares: 10000000,
+          }}
+        />
+      </Wrapper>
+    );
+
+    // Percentages
+    await waitFor(() => {
+      expect(screen.getByText(/1%/i)).toBeInTheDocument();
+      expect(screen.getByText(/0%/i)).toBeInTheDocument();
+    });
+
+    // Status: loader
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/getting off-chain voting status/i)
+      ).toBeInTheDocument();
+    });
+
+    // Status
+    await waitFor(() => {
+      expect(screen.getByText(/approved/i)).toBeInTheDocument();
+    });
+  });
+
+  test('should render correct content when "countdownGracePeriodStartMs" provided', async () => {
+    render(
+      <Wrapper
+        useInit
+        useWallet
+        getProps={({mockWeb3Provider, web3Instance}) => {
+          // Inject mocked result for grace period end
+          const result: [string] = [
+            web3Instance.eth.abi.encodeParameter('uint256', 3),
+          ];
+          mockWeb3Provider.injectResult(...result);
+
+          // Inject mocked results for total shares and single vote
+          mockWeb3Provider.injectResult(
+            web3Instance.eth.abi.encodeParameters(
+              ['uint256', 'bytes[]'],
+              [
+                0,
+                [
+                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+                ],
+              ]
+            ),
+            {abi: MulticallABI, abiMethodName: 'aggregate'}
+          );
+        }}>
+        <OffchainVotingStatus
+          countdownGracePeriodStartMs={Date.now()}
+          proposal={fakeProposal as ProposalData}
+        />
+      </Wrapper>
+    );
+
+    // Percentages
+    await waitFor(() => {
+      expect(screen.getByText(/1%/i)).toBeInTheDocument();
+      expect(screen.getByText(/0%/i)).toBeInTheDocument();
+    });
+
+    // Status: loader
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/getting off-chain voting status/i)
+      ).toBeInTheDocument();
+    });
+
+    // Grace period label
+    await waitFor(
+      () => {
+        expect(screen.getByText(/grace period ends/i)).toBeInTheDocument();
+      },
+      {timeout: 2000}
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/grace period ended/i)).toBeInTheDocument();
+      },
+      {timeout: 2000}
+    );
+  });
+});


### PR DESCRIPTION
Fixes #208 

🥳 **Adds**

 - `OffchainVotingStatus` unit tests

✨ **Updates**

 - `OffchainVotingResult` types are now `VotingResult` to accommodate on-chain, off-chain yes/no voting
 - Adds `ariaLabel` prop to `CycleEllipsis`
 - Passes `votingResult` from `GovernanceProposalsList->ProposalCard`
 - `ProposalCard`, `OffchainVotingStatus` now accept `votingResult` prop
