### PR TITLE
Updates Proposals, GovernanceProposalsList to accept render prop for proposal card

### DIFF
--- a/src/components/governance/GovernanceProposalsList.tsx
+++ b/src/components/governance/GovernanceProposalsList.tsx
@@ -16,7 +16,12 @@ type GovernanceProposalsListProps = {
    * The `actionId` to get proposals for in Snapshot Hub.
    */
   actionId?: string;
-  onProposalClick: (id: string) => void;
+  /**
+   * Optionally provide a click handler for `ProposalCard`.
+   * The proposal's id (in Snapshot) will be provided as an argument.
+   * Defaults to noop: `() => {}`
+   */
+  onProposalClick?: (id: string) => void;
   /**
    * Optionally render a custom proposal card.
    */
@@ -36,7 +41,11 @@ type FilteredProposals = {
 export default function GovernanceProposalsList(
   props: GovernanceProposalsListProps
 ): JSX.Element {
-  const {actionId = BURN_ADDRESS, onProposalClick, renderProposalCard} = props;
+  const {
+    actionId = BURN_ADDRESS,
+    onProposalClick = () => {},
+    renderProposalCard,
+  } = props;
 
   /**
    * State

--- a/src/components/governance/GovernanceProposalsList.tsx
+++ b/src/components/governance/GovernanceProposalsList.tsx
@@ -3,7 +3,7 @@ import React, {Fragment, useEffect, useState} from 'react';
 import {AsyncStatus} from '../../util/types';
 import {BURN_ADDRESS} from '../../util/constants';
 import {normalizeString} from '../../util/helpers';
-import {ProposalData, SnapshotProposal, VotingResult} from '../proposals/types';
+import {ProposalData, VotingResult} from '../proposals/types';
 import {ProposalHeaderNames} from '../../util/enums';
 import {useGovernanceProposals} from './hooks';
 import {useOffchainVotingResults} from '../proposals/hooks';
@@ -17,8 +17,11 @@ type GovernanceProposalsListProps = {
    */
   actionId?: string;
   onProposalClick: (id: string) => void;
+  /**
+   * Optionally render a custom proposal card.
+   */
   renderProposalCard?: (data: {
-    proposal: SnapshotProposal;
+    proposalData: ProposalData;
     votingResult?: VotingResult;
   }) => React.ReactNode;
 };
@@ -160,11 +163,10 @@ export default function GovernanceProposalsList(
     proposals: ProposalData[]
   ): React.ReactNode | null {
     return proposals.map((proposal) => {
-      const {snapshotProposal} = proposal;
       const proposalId = proposal.snapshotProposal?.idInSnapshot;
       const proposalName = proposal.snapshotProposal?.msg.payload.name || '';
 
-      if (!snapshotProposal || !proposalId) return null;
+      if (!proposalId) return null;
 
       const offchainResult = offchainVotingResults.find(
         ([proposalHash, _result]) =>
@@ -175,7 +177,7 @@ export default function GovernanceProposalsList(
         return (
           <Fragment key={proposalId}>
             {renderProposalCard({
-              proposal: snapshotProposal,
+              proposalData: proposal,
               votingResult: offchainResult,
             })}
           </Fragment>

--- a/src/components/governance/GovernanceProposalsList.unit.test.tsx
+++ b/src/components/governance/GovernanceProposalsList.unit.test.tsx
@@ -5,14 +5,15 @@ import {
 } from '@openlaw/snapshot-js-erc712';
 
 import {BURN_ADDRESS} from '../../util/constants';
-import {DEFAULT_ETH_ADDRESS} from '../../test/helpers';
+import {DEFAULT_ETH_ADDRESS, FakeHttpProvider} from '../../test/helpers';
 import {rest, server} from '../../test/server';
 import {SNAPSHOT_HUB_API_URL} from '../../config';
 import {snapshotAPIProposalResponse} from '../../test/restResponses';
 import GovernanceProposalsList from './GovernanceProposalsList';
 import MulticallABI from '../../truffle-contracts/Multicall.json';
-import Wrapper from '../../test/Wrapper';
 import userEvent from '@testing-library/user-event';
+import Wrapper from '../../test/Wrapper';
+import Web3 from 'web3';
 
 describe('GovernanceProposalsList unit tests', () => {
   const defaultProposalVotes: SnapshotProposalResponseData['votes'] = [
@@ -124,6 +125,66 @@ describe('GovernanceProposalsList unit tests', () => {
       },
       votes: defaultProposalVotes,
     },
+  };
+
+  const getWeb3Results = ({
+    mockWeb3Provider,
+    web3Instance,
+  }: {
+    mockWeb3Provider: FakeHttpProvider;
+    web3Instance: Web3;
+  }) => {
+    /**
+     * Inject voting results. The order should align with the order above of fake responses.
+     */
+
+    // 1. Inject passed result
+    mockWeb3Provider.injectResult(
+      web3Instance.eth.abi.encodeParameters(
+        ['uint256', 'bytes[]'],
+        [
+          0,
+          [
+            web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+            web3Instance.eth.abi.encodeParameter('uint256', '200000'),
+            web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+          ],
+        ]
+      ),
+      {abi: MulticallABI, abiMethodName: 'aggregate'}
+    );
+
+    // 2. Inject failed result
+    mockWeb3Provider.injectResult(
+      web3Instance.eth.abi.encodeParameters(
+        ['uint256', 'bytes[]'],
+        [
+          0,
+          [
+            web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+            web3Instance.eth.abi.encodeParameter('uint256', '200000'),
+            web3Instance.eth.abi.encodeParameter('uint256', '300000'),
+          ],
+        ]
+      ),
+      {abi: MulticallABI, abiMethodName: 'aggregate'}
+    );
+
+    // 3. Inject voting result
+    mockWeb3Provider.injectResult(
+      web3Instance.eth.abi.encodeParameters(
+        ['uint256', 'bytes[]'],
+        [
+          0,
+          [
+            web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
+            web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+            web3Instance.eth.abi.encodeParameter('uint256', '100000'),
+          ],
+        ]
+      ),
+      {abi: MulticallABI, abiMethodName: 'aggregate'}
+    );
   };
 
   test('should render proposal cards', async () => {
@@ -240,62 +301,7 @@ describe('GovernanceProposalsList unit tests', () => {
     );
 
     render(
-      <Wrapper
-        useInit
-        useWallet
-        getProps={({mockWeb3Provider, web3Instance}) => {
-          /**
-           * Inject voting results. The order should align with the order above of fake responses.
-           */
-
-          // 1. Inject passed result
-          mockWeb3Provider.injectResult(
-            web3Instance.eth.abi.encodeParameters(
-              ['uint256', 'bytes[]'],
-              [
-                0,
-                [
-                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
-                  web3Instance.eth.abi.encodeParameter('uint256', '200000'),
-                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
-                ],
-              ]
-            ),
-            {abi: MulticallABI, abiMethodName: 'aggregate'}
-          );
-
-          // 2. Inject failed result
-          mockWeb3Provider.injectResult(
-            web3Instance.eth.abi.encodeParameters(
-              ['uint256', 'bytes[]'],
-              [
-                0,
-                [
-                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
-                  web3Instance.eth.abi.encodeParameter('uint256', '200000'),
-                  web3Instance.eth.abi.encodeParameter('uint256', '300000'),
-                ],
-              ]
-            ),
-            {abi: MulticallABI, abiMethodName: 'aggregate'}
-          );
-
-          // 3. Inject voting result
-          mockWeb3Provider.injectResult(
-            web3Instance.eth.abi.encodeParameters(
-              ['uint256', 'bytes[]'],
-              [
-                0,
-                [
-                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
-                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
-                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
-                ],
-              ]
-            ),
-            {abi: MulticallABI, abiMethodName: 'aggregate'}
-          );
-        }}>
+      <Wrapper useInit useWallet getProps={getWeb3Results}>
         <GovernanceProposalsList
           actionId={BURN_ADDRESS}
           onProposalClick={() => {}}
@@ -335,62 +341,7 @@ describe('GovernanceProposalsList unit tests', () => {
     );
 
     render(
-      <Wrapper
-        useInit
-        useWallet
-        getProps={({mockWeb3Provider, web3Instance}) => {
-          /**
-           * Inject voting results. The order should align with the order above of fake responses.
-           */
-
-          // 1. Inject passed result
-          mockWeb3Provider.injectResult(
-            web3Instance.eth.abi.encodeParameters(
-              ['uint256', 'bytes[]'],
-              [
-                0,
-                [
-                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
-                  web3Instance.eth.abi.encodeParameter('uint256', '200000'),
-                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
-                ],
-              ]
-            ),
-            {abi: MulticallABI, abiMethodName: 'aggregate'}
-          );
-
-          // 2. Inject failed result
-          mockWeb3Provider.injectResult(
-            web3Instance.eth.abi.encodeParameters(
-              ['uint256', 'bytes[]'],
-              [
-                0,
-                [
-                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
-                  web3Instance.eth.abi.encodeParameter('uint256', '200000'),
-                  web3Instance.eth.abi.encodeParameter('uint256', '300000'),
-                ],
-              ]
-            ),
-            {abi: MulticallABI, abiMethodName: 'aggregate'}
-          );
-
-          // 3. Inject voting result
-          mockWeb3Provider.injectResult(
-            web3Instance.eth.abi.encodeParameters(
-              ['uint256', 'bytes[]'],
-              [
-                0,
-                [
-                  web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
-                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
-                  web3Instance.eth.abi.encodeParameter('uint256', '100000'),
-                ],
-              ]
-            ),
-            {abi: MulticallABI, abiMethodName: 'aggregate'}
-          );
-        }}>
+      <Wrapper useInit useWallet getProps={getWeb3Results}>
         <GovernanceProposalsList
           actionId={BURN_ADDRESS}
           onProposalClick={() => {}}
@@ -419,6 +370,61 @@ describe('GovernanceProposalsList unit tests', () => {
       expect(() => screen.getByText(/another cool one/i)).toThrow();
       expect(() => screen.getByText(/another rad one/i)).toThrow();
       expect(() => screen.getByText(/another awesome one/i)).toThrow();
+    });
+  });
+
+  test('should render custom proposal card', async () => {
+    const spy = jest.fn();
+
+    server.use(
+      ...[
+        rest.get(
+          `${SNAPSHOT_HUB_API_URL}/api/:spaceName/proposals/:adapterAddress`,
+          async (_req, res, ctx) => res(ctx.json(proposalsResponse))
+        ),
+      ]
+    );
+
+    render(
+      <Wrapper useInit useWallet getProps={getWeb3Results}>
+        <GovernanceProposalsList
+          actionId={BURN_ADDRESS}
+          onProposalClick={spy}
+          renderProposalCard={({proposal, votingResult}) => (
+            <div>
+              <h2>{`custom card: ${proposal.msg.payload.name}`}</h2>
+              <p>Yes votes: {votingResult?.Yes.shares}</p>
+              <p>No votes: {votingResult?.No.shares}</p>
+            </div>
+          )}
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/loading content/i)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      // Proposal headers
+      expect(screen.getByText(/^voting$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^passed$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^failed$/i)).toBeInTheDocument();
+
+      // Proposal names
+      expect(
+        screen.getByText(/^custom card: another awesome one$/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/^custom card: another cool one$/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/^custom card: another rad one$/i)
+      ).toBeInTheDocument();
+
+      // Voting result
+      expect(screen.getAllByText(/^yes votes: \d+$/i).length).toBe(3);
+      expect(screen.getAllByText(/^no votes: \d+$/i).length).toBe(3);
     });
   });
 });

--- a/src/components/governance/GovernanceProposalsList.unit.test.tsx
+++ b/src/components/governance/GovernanceProposalsList.unit.test.tsx
@@ -390,9 +390,9 @@ describe('GovernanceProposalsList unit tests', () => {
         <GovernanceProposalsList
           actionId={BURN_ADDRESS}
           onProposalClick={spy}
-          renderProposalCard={({proposal, votingResult}) => (
+          renderProposalCard={({proposalData, votingResult}) => (
             <div>
-              <h2>{`custom card: ${proposal.msg.payload.name}`}</h2>
+              <h2>{`custom card: ${proposalData.snapshotProposal?.msg.payload.name}`}</h2>
               <p>Yes votes: {votingResult?.Yes.shares}</p>
               <p>No votes: {votingResult?.No.shares}</p>
             </div>

--- a/src/components/proposals/Proposals.tsx
+++ b/src/components/proposals/Proposals.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {Fragment, useEffect, useState} from 'react';
 
 import {AsyncStatus} from '../../util/types';
 import {DaoAdapterConstants} from '../adapters-extensions/enums';
@@ -13,7 +13,16 @@ import ProposalCard from './ProposalCard';
 
 type ProposalsProps = {
   adapterName: DaoAdapterConstants;
-  onProposalClick: (id: string) => void;
+  /**
+   * Optionally provide a click handler for `ProposalCard`.
+   * The proposal's id (in the DAO) will be provided as an argument.
+   * Defaults to noop: `() => {}`
+   */
+  onProposalClick?: (id: string) => void;
+  /**
+   * Optionally render a custom proposal card.
+   */
+  renderProposalCard?: (data: {proposalData: ProposalData}) => React.ReactNode;
 };
 
 type FilteredProposals = {
@@ -24,7 +33,7 @@ type FilteredProposals = {
 };
 
 export default function Proposals(props: ProposalsProps): JSX.Element {
-  const {adapterName, onProposalClick} = props;
+  const {adapterName, onProposalClick = () => {}, renderProposalCard} = props;
 
   /**
    * State
@@ -184,6 +193,14 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
         '';
 
       if (!proposalId) return null;
+
+      if (renderProposalCard) {
+        return (
+          <Fragment key={proposalId}>
+            {renderProposalCard({proposalData: proposal})}
+          </Fragment>
+        );
+      }
 
       return (
         <ProposalCard

--- a/src/components/proposals/Proposals.unit.test.tsx
+++ b/src/components/proposals/Proposals.unit.test.tsx
@@ -5,12 +5,13 @@ import {
   snapshotAPIProposalResponse,
 } from '../../test/restResponses';
 import {DaoAdapterConstants} from '../adapters-extensions/enums';
-import {DEFAULT_ETH_ADDRESS} from '../../test/helpers';
+import {DEFAULT_ETH_ADDRESS, FakeHttpProvider} from '../../test/helpers';
 import {rest, server} from '../../test/server';
 import {SNAPSHOT_HUB_API_URL} from '../../config';
 import Proposals from './Proposals';
 import Wrapper from '../../test/Wrapper';
 import userEvent from '@testing-library/user-event';
+import Web3 from 'web3';
 
 describe('ProposalCard unit tests', () => {
   // Build our mock REST call responses for Snapshot Hub
@@ -95,6 +96,113 @@ describe('ProposalCard unit tests', () => {
     },
   };
 
+  const getWeb3Results = ({
+    mockWeb3Provider,
+    web3Instance,
+  }: {
+    mockWeb3Provider: FakeHttpProvider;
+    web3Instance: Web3;
+  }) => {
+    // Mock the proposals' multicall response
+    mockWeb3Provider.injectResult(
+      web3Instance.eth.abi.encodeParameters(
+        ['uint256', 'bytes[]'],
+        [
+          0,
+          [
+            web3Instance.eth.abi.encodeParameter(
+              {
+                Proposal: {
+                  adapterAddress: 'address',
+                  flags: 'uint256',
+                },
+              },
+              {
+                adapterAddress: DEFAULT_ETH_ADDRESS,
+                // ProposalFlag.EXISTS
+                flags: '1',
+              }
+            ),
+            web3Instance.eth.abi.encodeParameter(
+              {
+                Proposal: {
+                  adapterAddress: 'address',
+                  flags: 'uint256',
+                },
+              },
+              {
+                adapterAddress: DEFAULT_ETH_ADDRESS,
+                // ProposalFlag.EXISTS
+                flags: '1',
+              }
+            ),
+            web3Instance.eth.abi.encodeParameter(
+              {
+                Proposal: {
+                  adapterAddress: 'address',
+                  flags: 'uint256',
+                },
+              },
+              {
+                adapterAddress: DEFAULT_ETH_ADDRESS,
+                // ProposalFlag.PROCESSED
+                flags: '7',
+              }
+            ),
+            web3Instance.eth.abi.encodeParameter(
+              {
+                Proposal: {
+                  adapterAddress: 'address',
+                  flags: 'uint256',
+                },
+              },
+              {
+                adapterAddress: DEFAULT_ETH_ADDRESS,
+                // ProposalFlag.PROCESSED
+                flags: '7',
+              }
+            ),
+            web3Instance.eth.abi.encodeParameter(
+              {
+                Proposal: {
+                  adapterAddress: 'address',
+                  flags: 'uint256',
+                },
+              },
+              {
+                adapterAddress: DEFAULT_ETH_ADDRESS,
+                // ProposalFlag.SPONSORED
+                flags: '3',
+              }
+            ),
+          ],
+        ]
+      )
+    );
+
+    // Mock proposals' voting state multicall response
+    mockWeb3Provider.injectResult(
+      web3Instance.eth.abi.encodeParameters(
+        ['uint256', 'bytes[]'],
+        [
+          0,
+          [
+            // VotingState.NOT_STARTED
+            web3Instance.eth.abi.encodeParameter('uint8', '0'),
+            // VotingState.NOT_STARTED
+            web3Instance.eth.abi.encodeParameter('uint8', '0'),
+            // VotingState.PASS
+            web3Instance.eth.abi.encodeParameter('uint8', '2'),
+            // VotingState.NOT_PASS
+            web3Instance.eth.abi.encodeParameter('uint8', '3'),
+            // VotingState.IN_PROGRESS
+            web3Instance.eth.abi.encodeParameter('uint8', '4'),
+          ],
+        ]
+      )
+    );
+  };
+
   test('should render adapter proposal cards', async () => {
     const spy = jest.fn();
 
@@ -112,109 +220,7 @@ describe('ProposalCard unit tests', () => {
     );
 
     render(
-      <Wrapper
-        useInit
-        useWallet
-        getProps={({mockWeb3Provider, web3Instance}) => {
-          // Mock the proposals' multicall response
-          mockWeb3Provider.injectResult(
-            web3Instance.eth.abi.encodeParameters(
-              ['uint256', 'bytes[]'],
-              [
-                0,
-                [
-                  web3Instance.eth.abi.encodeParameter(
-                    {
-                      Proposal: {
-                        adapterAddress: 'address',
-                        flags: 'uint256',
-                      },
-                    },
-                    {
-                      adapterAddress: DEFAULT_ETH_ADDRESS,
-                      // ProposalFlag.EXISTS
-                      flags: '1',
-                    }
-                  ),
-                  web3Instance.eth.abi.encodeParameter(
-                    {
-                      Proposal: {
-                        adapterAddress: 'address',
-                        flags: 'uint256',
-                      },
-                    },
-                    {
-                      adapterAddress: DEFAULT_ETH_ADDRESS,
-                      // ProposalFlag.EXISTS
-                      flags: '1',
-                    }
-                  ),
-                  web3Instance.eth.abi.encodeParameter(
-                    {
-                      Proposal: {
-                        adapterAddress: 'address',
-                        flags: 'uint256',
-                      },
-                    },
-                    {
-                      adapterAddress: DEFAULT_ETH_ADDRESS,
-                      // ProposalFlag.PROCESSED
-                      flags: '7',
-                    }
-                  ),
-                  web3Instance.eth.abi.encodeParameter(
-                    {
-                      Proposal: {
-                        adapterAddress: 'address',
-                        flags: 'uint256',
-                      },
-                    },
-                    {
-                      adapterAddress: DEFAULT_ETH_ADDRESS,
-                      // ProposalFlag.PROCESSED
-                      flags: '7',
-                    }
-                  ),
-                  web3Instance.eth.abi.encodeParameter(
-                    {
-                      Proposal: {
-                        adapterAddress: 'address',
-                        flags: 'uint256',
-                      },
-                    },
-                    {
-                      adapterAddress: DEFAULT_ETH_ADDRESS,
-                      // ProposalFlag.SPONSORED
-                      flags: '3',
-                    }
-                  ),
-                ],
-              ]
-            )
-          );
-
-          // Mock proposals' voting state multicall response
-          mockWeb3Provider.injectResult(
-            web3Instance.eth.abi.encodeParameters(
-              ['uint256', 'bytes[]'],
-              [
-                0,
-                [
-                  // VotingState.NOT_STARTED
-                  web3Instance.eth.abi.encodeParameter('uint8', '0'),
-                  // VotingState.NOT_STARTED
-                  web3Instance.eth.abi.encodeParameter('uint8', '0'),
-                  // VotingState.PASS
-                  web3Instance.eth.abi.encodeParameter('uint8', '2'),
-                  // VotingState.NOT_PASS
-                  web3Instance.eth.abi.encodeParameter('uint8', '3'),
-                  // VotingState.IN_PROGRESS
-                  web3Instance.eth.abi.encodeParameter('uint8', '4'),
-                ],
-              ]
-            )
-          );
-        }}>
+      <Wrapper useInit useWallet getProps={getWeb3Results}>
         <Proposals
           adapterName={DaoAdapterConstants.ONBOARDING}
           onProposalClick={spy}
@@ -346,6 +352,66 @@ describe('ProposalCard unit tests', () => {
       expect(() => screen.getByText(/another great one/i)).toThrow();
       expect(() => screen.getByText(/another rad one/i)).toThrow();
       expect(() => screen.getByText(/another awesome one/i)).toThrow();
+    });
+  });
+
+  test('should render custom proposal card', async () => {
+    server.use(
+      ...[
+        rest.get(
+          `${SNAPSHOT_HUB_API_URL}/api/:spaceName/drafts/:adapterAddress`,
+          async (_req, res, ctx) => res(ctx.json(draftsResponse))
+        ),
+        rest.get(
+          `${SNAPSHOT_HUB_API_URL}/api/:spaceName/proposals/:adapterAddress`,
+          async (_req, res, ctx) => res(ctx.json(proposalsResponse))
+        ),
+      ]
+    );
+
+    render(
+      <Wrapper useInit useWallet getProps={getWeb3Results}>
+        <Proposals
+          adapterName={DaoAdapterConstants.ONBOARDING}
+          renderProposalCard={({proposalData}) => (
+            <div>
+              <h2>{`custom card: ${
+                proposalData.snapshotDraft?.msg.payload.name ||
+                proposalData.snapshotProposal?.msg.payload.name
+              }`}</h2>
+            </div>
+          )}
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/loading content/i)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      // Proposal headers
+      expect(screen.getByText(/^proposals$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^passed$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^failed$/i)).toBeInTheDocument();
+      expect(screen.getByText(/^voting$/i)).toBeInTheDocument();
+
+      // Proposal names
+      expect(
+        screen.getByText(/custom card: another nice one/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/custom card: another cool one/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/custom card: another great one/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/custom card: another rad one/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/custom card: another awesome one/i)
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Fixes #213 

✨ **Updates**

 - `GovernanceProposalsList` now accepts a render prop for the proposal card.
 - `Proposals` now accepts a render prop for the proposal card.
 - `GovernanceProposalsList` `onProposalClick` prop now optional.
 - `Proposals` `onProposalClick` prop now optional.
 - Updates `GovernanceProposalsList` unit tests
 - Updates `Proposals` unit tests
  
🧹 **Chores done**
 
 - Simplifies mocked web3 responses in `GovernanceProposalsList.unit.test`
 - Simplifies mocked web3 responses in `Proposals.unit.test`
