### PR TITLE
Adds Redux state and Apollo error link handler for when subgraph has network error, comes back up

### DIFF
--- a/src/gql/handleSubgraphError.ts
+++ b/src/gql/handleSubgraphError.ts
@@ -1,0 +1,67 @@
+import {ApolloLink} from '@apollo/client';
+import {onError} from '@apollo/client/link/error';
+import {Store} from 'redux';
+
+import {setSubgraphNetworkStatus} from '../store/actions';
+import {SubgraphNetworkStatus} from '../store/subgraphNetworkStatus/types';
+import {StoreState} from '../store/types';
+
+/**
+ * handleSubgraphError
+ *
+ * Handles an error from The Graph's GQL server at the Apollo
+ * Link level.
+ *
+ * Handles network errors from The Graph's GQL server.
+ *
+ * About network errors from the Apollo Docs:
+ *
+ *   "Network errors occur "These are errors encountered while attempting
+ *    to communicate with your GraphQL server, usually resulting in a
+ *    4xx or 5xx response status code (and no data)."
+ *
+ * We do not handle GQL errors that arise from individual queries.
+ * Perhaps it best to handle those inside of the concerned components
+ * (i.e. IF query error || subgraph is down THEN fallback)
+ *
+ * About GQL errors from the Apollo Docs:
+ *
+ *  - Syntax errors (e.g., a query was malformed)
+ *  - Validation errors (e.g., a query included a schema field that doesn't exist)
+ *  - Resolver errors (e.g., an error occurred while attempting to populate a query field)
+ *
+ * @param {Store} store
+ * @returns {ApolloLink}
+ * @link https://www.apollographql.com/docs/react/data/error-handling
+ */
+export function handleSubgraphError(store: Store): ApolloLink {
+  return onError(({/* graphQLErrors */ networkError}) => {
+    if (networkError) {
+      const reduxStateNotYetSet =
+        (store.getState() as StoreState).subgraphNetworkStatus.status !==
+        SubgraphNetworkStatus.ERR;
+
+      if (reduxStateNotYetSet) {
+        store.dispatch(
+          setSubgraphNetworkStatus({status: SubgraphNetworkStatus.ERR})
+        );
+
+        // Show error once
+        console.error(`[Subgraph network error]: ${networkError}`);
+      }
+    }
+
+    // Reset when there's no more network error
+    if (!networkError) {
+      const reduxStateNotYetSet =
+        (store.getState() as StoreState).subgraphNetworkStatus.status !==
+        SubgraphNetworkStatus.OK;
+
+      if (reduxStateNotYetSet) {
+        store.dispatch(
+          setSubgraphNetworkStatus({status: SubgraphNetworkStatus.OK})
+        );
+      }
+    }
+  });
+}

--- a/src/gql/index.ts
+++ b/src/gql/index.ts
@@ -1,2 +1,6 @@
+// Queries
 export * from './queryDao';
 export * from './queryAdaptersAndExtensions';
+
+// Other
+export * from './handleSubgraphError';

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,2 +1,3 @@
 export * from './connectedMember/actions';
 export * from './contracts/actions';
+export * from './subgraphNetworkStatus/actions';

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -2,8 +2,10 @@ import {combineReducers} from 'redux';
 
 import connectedMember from './connectedMember/reducers';
 import contracts from './contracts/reducers';
+import subgraphNetworkStatus from './subgraphNetworkStatus/reducers';
 
 export default combineReducers({
   connectedMember,
   contracts,
+  subgraphNetworkStatus,
 });

--- a/src/store/subgraphNetworkStatus/actions.ts
+++ b/src/store/subgraphNetworkStatus/actions.ts
@@ -1,0 +1,7 @@
+import {SubgraphNetworkStatusState} from './types';
+
+export const SET_SUBGRAPH_NETWORK_STATUS = 'SET_SUBGRAPH_NETWORK_STATUS';
+
+export function setSubgraphNetworkStatus(payload: SubgraphNetworkStatusState) {
+  return {type: SET_SUBGRAPH_NETWORK_STATUS, ...payload};
+}

--- a/src/store/subgraphNetworkStatus/reducers.ts
+++ b/src/store/subgraphNetworkStatus/reducers.ts
@@ -1,0 +1,27 @@
+import {SET_SUBGRAPH_NETWORK_STATUS} from './actions';
+import {SubgraphNetworkStatus, SubgraphNetworkStatusState} from './types';
+
+const INITIAL_STATE = {
+  status: SubgraphNetworkStatus.OK,
+};
+
+export default function reducer(
+  state: SubgraphNetworkStatusState = INITIAL_STATE,
+  action: any
+) {
+  const {type, ...payload} = action;
+
+  switch (type) {
+    case SET_SUBGRAPH_NETWORK_STATUS:
+      return setConnectedMemberReducer(state, payload);
+    default:
+      return state;
+  }
+}
+
+function setConnectedMemberReducer(
+  state: Partial<SubgraphNetworkStatusState>,
+  payload: Record<string, any>
+) {
+  return {...state, ...payload};
+}

--- a/src/store/subgraphNetworkStatus/types.ts
+++ b/src/store/subgraphNetworkStatus/types.ts
@@ -1,0 +1,8 @@
+export enum SubgraphNetworkStatus {
+  OK = 'OK',
+  ERR = 'ERR',
+}
+
+export type SubgraphNetworkStatusState = {
+  status: SubgraphNetworkStatus;
+};

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -8,6 +8,7 @@ import {
   DaoExtensionConstants,
   VotingAdapterName,
 } from '../components/adapters-extensions/enums';
+import {SubgraphNetworkStatusState} from './subgraphNetworkStatus/types';
 
 export type ContractsState = {
   BankExtensionContract: ContractsStateEntry | null;
@@ -34,6 +35,7 @@ export type ConnectedMemberState = {
 export type StoreState = {
   connectedMember: ConnectedMemberState;
   contracts: ContractsState;
+  subgraphNetworkStatus: SubgraphNetworkStatusState;
 };
 
 export type ContractsStateEntry = {


### PR DESCRIPTION
Fixes #190 

🥳 **Adds**

 - Redux state boilerplate for `subgraphNetworkStatus`
   - Adds new `types` to its redux dir
 - Handler for setting redux state based on GQL network error / no error

✨ **Updates**

 - `ApolloClient` to use `link: ...` prop instead of `uri` so we can add an error link +  terminating `HttpLink(...)`
 

