### PR TITLE
Moves store/contracts state to types file

### DIFF
--- a/src/Init.tsx
+++ b/src/Init.tsx
@@ -2,8 +2,9 @@ import React, {useCallback, useEffect, useState} from 'react';
 import {getApiStatus as getSnapshotAPIStatus} from '@openlaw/snapshot-js-erc712';
 
 import {AsyncStatus} from './util/types';
+import {ContractsStateEntry} from './store/contracts/types';
 import {getConnectedMember} from './store/actions';
-import {ContractsStateEntry, ReduxDispatch, StoreState} from './store/types';
+import {ReduxDispatch, StoreState} from './store/types';
 import {SNAPSHOT_HUB_API_URL} from './config';
 import {useDispatch, useSelector} from 'react-redux';
 import {useInitContracts} from './components/web3/hooks';

--- a/src/components/web3/helpers/getAdapterAddress.ts
+++ b/src/components/web3/helpers/getAdapterAddress.ts
@@ -1,6 +1,6 @@
 import Web3 from 'web3';
 
-import {ContractsStateEntry} from '../../../store/types';
+import {ContractsStateEntry} from '../../../store/contracts/types';
 import {ContractAdapterNames} from '../types';
 
 export async function getAdapterAddress(

--- a/src/components/web3/helpers/getAdapterAddressFromContracts.ts
+++ b/src/components/web3/helpers/getAdapterAddressFromContracts.ts
@@ -1,5 +1,6 @@
 import {ContractAdapterNames} from '../types';
-import {ContractsStateEntry, StoreState} from '../../../store/types';
+import {ContractsStateEntry} from '../../../store/contracts/types';
+import {StoreState} from '../../../store/types';
 
 function getContractAddressOrThrow(
   contract: ContractsStateEntry | null

--- a/src/components/web3/helpers/getContractByAddress.ts
+++ b/src/components/web3/helpers/getContractByAddress.ts
@@ -1,5 +1,6 @@
+import {ContractsStateEntry} from '../../../store/contracts/types';
 import {normalizeString} from '../../../util/helpers';
-import {ContractsStateEntry, StoreState} from '../../../store/types';
+import {StoreState} from '../../../store/types';
 
 /**
  * getContractByAddress

--- a/src/components/web3/helpers/getDAOConfigEntry.ts
+++ b/src/components/web3/helpers/getDAOConfigEntry.ts
@@ -1,6 +1,6 @@
 import Web3 from 'web3';
 
-import {ContractsStateEntry} from '../../../store/types';
+import {ContractsStateEntry} from '../../../store/contracts/types';
 import {ContractDAOConfigKeys} from '../types';
 
 export async function getDAOConfigEntry(

--- a/src/components/web3/helpers/getDaoState.ts
+++ b/src/components/web3/helpers/getDaoState.ts
@@ -1,4 +1,4 @@
-import {ContractsStateEntry} from '../../../store/types';
+import {ContractsStateEntry} from '../../../store/contracts/types';
 
 export enum DaoState {
   CREATION = 'CREATION',

--- a/src/components/web3/helpers/getExtensionAddress.ts
+++ b/src/components/web3/helpers/getExtensionAddress.ts
@@ -1,6 +1,6 @@
 import Web3 from 'web3';
 
-import {ContractsStateEntry} from '../../../store/types';
+import {ContractsStateEntry} from '../../../store/contracts/types';
 import {ContractExtensionNames} from '../types';
 
 export async function getExtensionAddress(

--- a/src/store/connectedMember/actions.ts
+++ b/src/store/connectedMember/actions.ts
@@ -1,7 +1,7 @@
 import {Dispatch} from 'redux';
 
 import {BURN_ADDRESS} from '../../util/constants';
-import {ConnectedMemberState} from '../types';
+import {ConnectedMemberState} from '../connectedMember/types';
 import {ContractsStateEntry} from '../contracts/types';
 import {normalizeString} from '../../util/helpers';
 

--- a/src/store/connectedMember/actions.ts
+++ b/src/store/connectedMember/actions.ts
@@ -1,7 +1,8 @@
 import {Dispatch} from 'redux';
 
 import {BURN_ADDRESS} from '../../util/constants';
-import {ConnectedMemberState, ContractsStateEntry} from '../types';
+import {ConnectedMemberState} from '../types';
+import {ContractsStateEntry} from '../contracts/types';
 import {normalizeString} from '../../util/helpers';
 
 export const SET_CONNECTED_MEMBER = 'SET_CONNECTED_MEMBER';

--- a/src/store/connectedMember/reducers.ts
+++ b/src/store/connectedMember/reducers.ts
@@ -1,5 +1,5 @@
 import {CLEAR_CONNECTED_MEMBER, SET_CONNECTED_MEMBER} from './actions';
-import {ConnectedMemberState} from '../types';
+import {ConnectedMemberState} from './types';
 
 const INITIAL_STATE = null;
 

--- a/src/store/connectedMember/types.ts
+++ b/src/store/connectedMember/types.ts
@@ -1,0 +1,5 @@
+export type ConnectedMemberState = {
+  delegateKey: string;
+  isActiveMember: boolean;
+  memberAddress: string;
+} | null;

--- a/src/store/contracts/actions.ts
+++ b/src/store/contracts/actions.ts
@@ -11,9 +11,10 @@ import {
   DAO_FACTORY_CONTRACT_ADDRESS,
   DAO_REGISTRY_CONTRACT_ADDRESS,
 } from '../../config';
-import {ContractsStateEntry, StoreState} from '../types';
+import {ContractsStateEntry} from '../contracts/types';
 import {getAdapterAddress} from '../../components/web3/helpers';
 import {getExtensionAddress} from '../../components/web3/helpers/getExtensionAddress';
+import {StoreState} from '../types';
 import {
   DaoAdapterConstants,
   DaoExtensionConstants,

--- a/src/store/contracts/reducers.ts
+++ b/src/store/contracts/reducers.ts
@@ -14,7 +14,7 @@ import {
   CONTRACT_VOTING,
   CONTRACT_WITHDRAW,
 } from '../actions';
-import {ContractsState} from '../types';
+import {ContractsState} from './types';
 
 const initialState = {
   BankExtensionContract: null,

--- a/src/store/contracts/types.ts
+++ b/src/store/contracts/types.ts
@@ -1,0 +1,46 @@
+import {AbiItem} from 'web3-utils/types';
+import {Contract as Web3Contract} from 'web3-eth-contract/types';
+
+import {
+  DaoAdapterConstants,
+  DaoExtensionConstants,
+  VotingAdapterName,
+} from '../../components/adapters-extensions/enums';
+
+export type ContractsStateEntry = {
+  /**
+   * Web3 `Contract` instance
+   */
+  instance: Web3Contract;
+  /**
+   * Contract JSON ABI
+   */
+  abi: AbiItem[];
+  /**
+   * (Optional) Adapter/extension name, used for the Adapter/Extension Management
+   */
+  adapterOrExtensionName?:
+    | DaoAdapterConstants
+    | DaoExtensionConstants
+    | VotingAdapterName;
+  /**
+   * Address of the instantiated contract
+   */
+  contractAddress: string;
+};
+
+export type ContractsState = {
+  BankExtensionContract: ContractsStateEntry | null;
+  ConfigurationContract: ContractsStateEntry | null;
+  DaoFactoryContract: ContractsStateEntry | null;
+  DaoRegistryContract: ContractsStateEntry | null;
+  DistributeContract: ContractsStateEntry | null;
+  FinancingContract: ContractsStateEntry | null;
+  GuildBankContract: ContractsStateEntry | null;
+  ManagingContract: ContractsStateEntry | null;
+  OnboardingContract: ContractsStateEntry | null;
+  RagequitContract: ContractsStateEntry | null;
+  TributeContract: ContractsStateEntry | null;
+  VotingContract: ContractsStateEntry | null;
+  WithdrawContract: ContractsStateEntry | null;
+};

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,30 +1,8 @@
 import {Action} from 'redux';
 import {ThunkDispatch} from 'redux-thunk';
-import {AbiItem} from 'web3-utils/types';
-import {Contract as Web3Contract} from 'web3-eth-contract/types';
 
-import {
-  DaoAdapterConstants,
-  DaoExtensionConstants,
-  VotingAdapterName,
-} from '../components/adapters-extensions/enums';
 import {SubgraphNetworkStatusState} from './subgraphNetworkStatus/types';
-
-export type ContractsState = {
-  BankExtensionContract: ContractsStateEntry | null;
-  ConfigurationContract: ContractsStateEntry | null;
-  DaoFactoryContract: ContractsStateEntry | null;
-  DaoRegistryContract: ContractsStateEntry | null;
-  DistributeContract: ContractsStateEntry | null;
-  FinancingContract: ContractsStateEntry | null;
-  GuildBankContract: ContractsStateEntry | null;
-  ManagingContract: ContractsStateEntry | null;
-  OnboardingContract: ContractsStateEntry | null;
-  RagequitContract: ContractsStateEntry | null;
-  TributeContract: ContractsStateEntry | null;
-  VotingContract: ContractsStateEntry | null;
-  WithdrawContract: ContractsStateEntry | null;
-};
+import {ContractsState} from './contracts/types';
 
 export type ConnectedMemberState = {
   delegateKey: string;
@@ -36,28 +14,6 @@ export type StoreState = {
   connectedMember: ConnectedMemberState;
   contracts: ContractsState;
   subgraphNetworkStatus: SubgraphNetworkStatusState;
-};
-
-export type ContractsStateEntry = {
-  /**
-   * Web3 `Contract` instance
-   */
-  instance: Web3Contract;
-  /**
-   * Contract JSON ABI
-   */
-  abi: AbiItem[];
-  /**
-   * (Optional) Adapter/extension name, used for the Adapter/Extension Management
-   */
-  adapterOrExtensionName?:
-    | DaoAdapterConstants
-    | DaoExtensionConstants
-    | VotingAdapterName;
-  /**
-   * Address of the instantiated contract
-   */
-  contractAddress: string;
 };
 
 /**

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,14 +1,9 @@
 import {Action} from 'redux';
 import {ThunkDispatch} from 'redux-thunk';
 
-import {SubgraphNetworkStatusState} from './subgraphNetworkStatus/types';
+import {ConnectedMemberState} from './connectedMember/types';
 import {ContractsState} from './contracts/types';
-
-export type ConnectedMemberState = {
-  delegateKey: string;
-  isActiveMember: boolean;
-  memberAddress: string;
-} | null;
+import {SubgraphNetworkStatusState} from './subgraphNetworkStatus/types';
 
 export type StoreState = {
   connectedMember: ConnectedMemberState;


### PR DESCRIPTION
🧹 **Chores done**
 
The store types file is getting bigger, so it's time to split them into their own files co-located with their Redux directories.

- [x] Co-locate contracts types
- [x] Co-locate connected member types
