### PR TITLE
Fix proposals listing when off-chain votes not yet submitted

### DIFF
--- a/src/components/proposals/Proposals.tsx
+++ b/src/components/proposals/Proposals.tsx
@@ -138,7 +138,7 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
 
       if (voteState === undefined || !p.daoProposal) return;
 
-      // @note Add other off-chain voting styles as needed (i.e. Batch)
+      // @note Add more logic for other off-chain voting styles as needed (i.e. Batch)
       const offchainResultNotYetSubmitted: boolean =
         proposalHasVotingState(VotingState.TIE, voteState) &&
         proposalHasFlag(ProposalFlag.SPONSORED, p.daoProposal.flags) &&

--- a/src/components/proposals/Proposals.tsx
+++ b/src/components/proposals/Proposals.tsx
@@ -6,6 +6,7 @@ import {ProposalData, ProposalFlag} from './types';
 import {proposalHasFlag, proposalHasVotingState} from './helpers';
 import {ProposalHeaderNames} from '../../util/enums';
 import {useProposals, useProposalsVotingState} from './hooks';
+import {useProposalsVotes} from './hooks/useProposalsVotes';
 import {VotingState} from './voting/types';
 import ErrorMessageWithDetails from '../common/ErrorMessageWithDetails';
 import LoaderWithEmoji from '../feedback/LoaderWithEmoji';
@@ -62,6 +63,10 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
     proposalsVotingStateError,
     proposalsVotingStateStatus,
   } = useProposalsVotingState(proposalIds);
+
+  const {proposalsVotes} = useProposalsVotes(proposalIds);
+
+  console.log('proposalsVotes', proposalsVotes);
 
   /**
    * Variables

--- a/src/components/proposals/Proposals.tsx
+++ b/src/components/proposals/Proposals.tsx
@@ -255,7 +255,6 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
 
   // Render no proposals
   if (
-    !Object.values(proposals).length &&
     !Object.values(filteredProposals).flatMap((p) => p).length &&
     proposalsStatus === AsyncStatus.FULFILLED
   ) {

--- a/src/components/proposals/Proposals.tsx
+++ b/src/components/proposals/Proposals.tsx
@@ -1,6 +1,7 @@
 import React, {Fragment, useEffect, useState} from 'react';
 
 import {AsyncStatus} from '../../util/types';
+import {BURN_ADDRESS} from '../../util/constants';
 import {DaoAdapterConstants} from '../adapters-extensions/enums';
 import {ProposalData, ProposalFlag} from './types';
 import {proposalHasFlag, proposalHasVotingState} from './helpers';
@@ -64,9 +65,11 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
     proposalsVotingStateStatus,
   } = useProposalsVotingState(proposalIds);
 
-  const {proposalsVotes} = useProposalsVotes(proposalIds);
-
-  console.log('proposalsVotes', proposalsVotes);
+  const {
+    proposalsVotes,
+    proposalsVotesError,
+    proposalsVotesStatus,
+  } = useProposalsVotes(proposalIds);
 
   /**
    * Variables
@@ -85,11 +88,15 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
     // Getting ready to fetch using `useProposalsVotingState`; helps to show continuous loader.
     (proposalsVotingStateStatus === AsyncStatus.STANDBY &&
       proposalIds.length > 0) ||
-    proposalsVotingStateStatus === AsyncStatus.PENDING;
+    proposalsVotingStateStatus === AsyncStatus.PENDING ||
+    // Getting ready to fetch using `useProposalsVotes`; helps to show continuous loader.
+    (proposalsVotesStatus === AsyncStatus.STANDBY && proposalIds.length > 0) ||
+    proposalsVotesStatus === AsyncStatus.PENDING;
 
   const isError: boolean =
     proposalsStatus === AsyncStatus.REJECTED ||
-    proposalsVotingStateStatus === AsyncStatus.REJECTED;
+    proposalsVotingStateStatus === AsyncStatus.REJECTED ||
+    proposalsVotesStatus === AsyncStatus.REJECTED;
 
   /**
    * Effects
@@ -110,6 +117,7 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
   useEffect(() => {
     if (proposalsStatus !== AsyncStatus.FULFILLED) return;
     if (proposalsVotingStateStatus !== AsyncStatus.FULFILLED) return;
+    if (proposalsVotesStatus !== AsyncStatus.FULFILLED) return;
 
     const filteredProposalsToSet: FilteredProposals = {
       failedProposals: [],
@@ -119,12 +127,22 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
     };
 
     proposals.forEach((p) => {
+      const proposalId =
+        p.snapshotDraft?.idInDAO || p.snapshotProposal?.idInDAO || '';
+
       const voteState = proposalsVotingState.find(
-        ([id]) =>
-          id === (p.snapshotDraft?.idInDAO || p.snapshotProposal?.idInDAO || '')
+        ([id]) => id === proposalId
       )?.[1];
 
+      const votesData = proposalsVotes.find(([id]) => id === proposalId)?.[1];
+
       if (voteState === undefined || !p.daoProposal) return;
+
+      // @note Add other off-chain voting styles as needed (i.e. Batch)
+      const offchainResultNotYetSubmitted: boolean =
+        proposalHasVotingState(VotingState.TIE, voteState) &&
+        proposalHasFlag(ProposalFlag.SPONSORED, p.daoProposal.flags) &&
+        votesData?.OffchainVotingContract?.reporter === BURN_ADDRESS;
 
       // non-sponsored proposal
       if (
@@ -138,9 +156,10 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
 
       // voting proposal
       if (
-        (proposalHasVotingState(VotingState.GRACE_PERIOD, voteState) ||
+        ((proposalHasVotingState(VotingState.GRACE_PERIOD, voteState) ||
           proposalHasVotingState(VotingState.IN_PROGRESS, voteState)) &&
-        proposalHasFlag(ProposalFlag.SPONSORED, p.daoProposal.flags)
+          proposalHasFlag(ProposalFlag.SPONSORED, p.daoProposal.flags)) ||
+        offchainResultNotYetSubmitted
       ) {
         filteredProposalsToSet.votingProposals.push(p);
 
@@ -178,6 +197,8 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
   }, [
     proposals,
     proposalsStatus,
+    proposalsVotes,
+    proposalsVotesStatus,
     proposalsVotingState,
     proposalsVotingStateStatus,
   ]);
@@ -246,7 +267,9 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
     return (
       <div className="text-center">
         <ErrorMessageWithDetails
-          error={proposalsError || proposalsVotingStateError}
+          error={
+            proposalsError || proposalsVotingStateError || proposalsVotesError
+          }
           renderText="Something went wrong while getting the proposals."
         />
       </div>

--- a/src/components/proposals/Proposals.unit.test.tsx
+++ b/src/components/proposals/Proposals.unit.test.tsx
@@ -4,14 +4,22 @@ import {
   snapshotAPIDraftResponse,
   snapshotAPIProposalResponse,
 } from '../../test/restResponses';
-import {DaoAdapterConstants} from '../adapters-extensions/enums';
-import {DEFAULT_ETH_ADDRESS, FakeHttpProvider} from '../../test/helpers';
+import {
+  DaoAdapterConstants,
+  VotingAdapterName,
+} from '../adapters-extensions/enums';
+import {
+  DEFAULT_ETH_ADDRESS,
+  DEFAULT_PROPOSAL_HASH,
+  FakeHttpProvider,
+} from '../../test/helpers';
+import {BURN_ADDRESS} from '../../util/constants';
 import {rest, server} from '../../test/server';
 import {SNAPSHOT_HUB_API_URL} from '../../config';
 import Proposals from './Proposals';
-import Wrapper from '../../test/Wrapper';
 import userEvent from '@testing-library/user-event';
 import Web3 from 'web3';
+import Wrapper from '../../test/Wrapper';
 
 describe('ProposalCard unit tests', () => {
   // Build our mock REST call responses for Snapshot Hub
@@ -201,6 +209,110 @@ describe('ProposalCard unit tests', () => {
         ]
       )
     );
+
+    // For `useProposalsVotes`
+    const noVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+      'address',
+      BURN_ADDRESS
+    );
+
+    // For `useProposalsVotes`
+    const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+      'address',
+      DEFAULT_ETH_ADDRESS
+    );
+
+    // For `useProposalsVotes`
+    const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+      'string',
+      VotingAdapterName.OffchainVotingContract
+    );
+
+    /**
+     * For `useProposalsVotes`
+     *
+     * @note Maintain the same order as the contract's struct.
+     */
+    const offchainVotesDataResponse = web3Instance.eth.abi.encodeParameter(
+      {
+        Voting: {
+          snapshot: 'uint256',
+          proposalHash: 'bytes32',
+          reporter: 'address',
+          resultRoot: 'bytes32',
+          nbVoters: 'uint256',
+          nbYes: 'uint256',
+          nbNo: 'uint256',
+          index: 'uint256',
+          startingTime: 'uint256',
+          gracePeriodStartingTime: 'uint256',
+          isChallenged: 'bool',
+          fallbackVotesCount: 'uint256',
+        },
+      },
+      {
+        snapshot: '8376297',
+        proposalHash: DEFAULT_PROPOSAL_HASH,
+        reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+        resultRoot:
+          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+        nbVoters: '0',
+        nbYes: '1',
+        nbNo: '0',
+        index: '0',
+        startingTime: '1617878162',
+        gracePeriodStartingTime: '1617964640',
+        isChallenged: false,
+        fallbackVotesCount: '0',
+      }
+    );
+
+    // `useProposalsVotes`: Mock `dao.votingAdapter` responses
+    mockWeb3Provider.injectResult(
+      web3Instance.eth.abi.encodeParameters(
+        ['uint256', 'bytes[]'],
+        [
+          0,
+          [
+            noVotingAdapterResponse,
+            noVotingAdapterResponse,
+            offchainVotingAdapterResponse,
+            offchainVotingAdapterResponse,
+            offchainVotingAdapterResponse,
+          ],
+        ]
+      )
+    );
+
+    // `useProposalsVotes`: Mock `IVoting.getAdapterName` responses
+    mockWeb3Provider.injectResult(
+      web3Instance.eth.abi.encodeParameters(
+        ['uint256', 'bytes[]'],
+        [
+          0,
+          [
+            offchainVotingAdapterNameResponse,
+            offchainVotingAdapterNameResponse,
+            offchainVotingAdapterNameResponse,
+          ],
+        ]
+      )
+    );
+
+    // `useProposalsVotes`: Mock votes data responses
+    mockWeb3Provider.injectResult(
+      web3Instance.eth.abi.encodeParameters(
+        ['uint256', 'bytes[]'],
+        [
+          0,
+          [
+            offchainVotesDataResponse,
+            offchainVotesDataResponse,
+            offchainVotesDataResponse,
+          ],
+        ]
+      )
+    );
   };
 
   test('should render adapter proposal cards', async () => {
@@ -305,13 +417,13 @@ describe('ProposalCard unit tests', () => {
     });
   });
 
-  // @note Just to throw something we purposefully do not mock the multicall responses
-  test('should render error', async () => {
+  test('should render error if a snapshot hub api call is bad', async () => {
     server.use(
       ...[
+        // Return a 500 error
         rest.get(
           `${SNAPSHOT_HUB_API_URL}/api/:spaceName/drafts/:adapterAddress`,
-          async (_req, res, ctx) => res(ctx.json(draftsResponse))
+          async (_req, res, ctx) => res(ctx.status(500))
         ),
         rest.get(
           `${SNAPSHOT_HUB_API_URL}/api/:spaceName/proposals/:adapterAddress`,
@@ -332,6 +444,11 @@ describe('ProposalCard unit tests', () => {
     await waitFor(() => {
       expect(
         screen.getByText(/something went wrong while getting the proposals/i)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /something went wrong while fetching the snapshot drafts/i
+        )
       ).toBeInTheDocument();
     });
 

--- a/src/components/proposals/hooks/useProposalsVotes.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.ts
@@ -1,0 +1,248 @@
+import {useCallback, useEffect, useState} from 'react';
+import {useSelector} from 'react-redux';
+import {AbiItem} from 'web3-utils/types';
+
+import {AsyncStatus} from '../../../util/types';
+import {multicall, MulticallTuple} from '../../web3/helpers';
+import {OffchainVotingAdapterVotes, VotingAdapterVotes} from '../types';
+import {StoreState} from '../../../store/types';
+import {useWeb3Modal} from '../../web3/hooks';
+import {VotingAdapterName} from '../../adapters-extensions/enums';
+
+type ProposalsVotesTuples = [
+  proposalId: string,
+  /**
+   * For each proposal, each result is stored under its adapter name.
+   */
+  adapterData: {
+    [VotingAdapterName.OffchainVotingContract]?: OffchainVotingAdapterVotes;
+    [VotingAdapterName.VotingContract]?: VotingAdapterVotes;
+  }
+][];
+
+type UseProposalsVotesReturn = {
+  proposalsVotes: ProposalsVotesTuples;
+  proposalsVotesError: Error | undefined;
+  proposalsVotesStatus: AsyncStatus;
+};
+
+export function useProposalsVotes(
+  proposalIds: string[]
+): UseProposalsVotesReturn {
+  /**
+   * Selectors
+   */
+
+  const registryAddress = useSelector(
+    (s: StoreState) => s.contracts.DaoRegistryContract?.contractAddress
+  );
+  const registryABI = useSelector(
+    (s: StoreState) => s.contracts.DaoRegistryContract?.abi
+  );
+
+  /**
+   * Our hooks
+   */
+
+  const {web3Instance} = useWeb3Modal();
+
+  /**
+   * State
+   */
+
+  const [proposalsVotes, setProposaslsVotes] = useState<ProposalsVotesTuples>(
+    []
+  );
+
+  const [proposalsVotesError, setProposalsVotesError] = useState<Error>();
+
+  const [proposalsVotesStatus, setProposalsVotesStatus] = useState<AsyncStatus>(
+    AsyncStatus.STANDBY
+  );
+
+  /**
+   * Cached callbacks
+   */
+
+  const getProposalsVotesOnchainCached = useCallback(getProposalsVotesOnchain, [
+    proposalIds,
+    registryABI,
+    registryAddress,
+    web3Instance,
+  ]);
+
+  /**
+   * Effects
+   */
+
+  useEffect(() => {
+    getProposalsVotesOnchainCached();
+  }, [getProposalsVotesOnchainCached]);
+
+  /**
+   * Functions
+   */
+
+  async function getProposalsVotesOnchain() {
+    if (!registryAddress || !registryABI || !proposalIds.length) {
+      return;
+    }
+
+    try {
+      const votingAdapterABI = registryABI.find(
+        (ai) => ai.name === 'votingAdapter'
+      );
+
+      if (!votingAdapterABI) {
+        throw new Error(
+          'No "votingAdapter" ABI function was found in the DAO registry ABI.'
+        );
+      }
+
+      // `DaoRegistry.votingAdapter` calls
+      const votingAdapterCalls: MulticallTuple[] = proposalIds.map((id) => [
+        registryAddress,
+        votingAdapterABI,
+        [id],
+      ]);
+
+      setProposalsVotesStatus(AsyncStatus.PENDING);
+
+      const votingAdapterAddressResults: string[] = await multicall({
+        calls: votingAdapterCalls,
+        web3Instance,
+      });
+
+      const {default: lazyIVotingABI} = await import(
+        '../../../truffle-contracts/IVoting.json'
+      );
+
+      const getAdapterNameABI = (lazyIVotingABI as typeof registryABI).find(
+        (ai) => ai.name === 'getAdapterName'
+      );
+
+      if (!getAdapterNameABI) {
+        throw new Error(
+          'No "getAdapterName" ABI function was found in the IVoting ABI.'
+        );
+      }
+
+      const votingAdapterNameCalls: MulticallTuple[] = votingAdapterAddressResults.map(
+        (votingAdapterAddress) => [votingAdapterAddress, getAdapterNameABI, []]
+      );
+
+      const adapterNameResults: VotingAdapterName[] = await multicall({
+        calls: votingAdapterNameCalls,
+        web3Instance,
+      });
+
+      let adapterNameMap: Record<string, VotingAdapterName>;
+
+      const votesDataCalls: MulticallTuple[] = await Promise.all(
+        proposalIds.map(
+          async (id, i): Promise<MulticallTuple> => {
+            adapterNameMap = {
+              [id]: adapterNameResults[i],
+            };
+
+            return [
+              votingAdapterAddressResults[i],
+              await getVotesDataABI(adapterNameResults[i]),
+              /**
+               * We build the call arguments the same way for the different voting adapters
+               * (i.e. [dao, proposalId]). If we need to change this we can move it to another function.
+               */
+              [registryAddress, id],
+            ];
+          }
+        )
+      );
+
+      const votesDataResults = await multicall({
+        calls: votesDataCalls,
+        web3Instance,
+      });
+
+      console.log('votesDataResults', votesDataResults);
+
+      setProposalsVotesStatus(AsyncStatus.FULFILLED);
+      setProposaslsVotes(
+        proposalIds.map((id, i) => [
+          id,
+          {
+            [adapterNameMap[id]]: votesDataResults[i],
+          },
+        ])
+      );
+    } catch (error) {
+      setProposalsVotesStatus(AsyncStatus.REJECTED);
+      setProposaslsVotes([]);
+      setProposalsVotesError(error);
+    }
+  }
+
+  /**
+   * getVotesDataABI
+   *
+   * Gets the ABI for the public mapping getter of voting data.
+   *
+   *
+   *
+   * @param {VotingAdapterName} votingAdapterName
+   * @returns {Promise<AbiItem | undefined>}
+   */
+  async function getVotesDataABI(
+    votingAdapterName: VotingAdapterName
+  ): Promise<AbiItem> {
+    try {
+      switch (votingAdapterName) {
+        case VotingAdapterName.OffchainVotingContract:
+          const {default: lazyOffchainVotingABI} = await import(
+            '../../../truffle-contracts/OffchainVotingContract.json'
+          );
+
+          const offchainVotesDataABI = (lazyOffchainVotingABI as AbiItem[]).find(
+            (ai) => ai.name === 'votes'
+          );
+
+          if (!offchainVotesDataABI) {
+            throw new Error(
+              `No "votes" function ABI was found for "${votingAdapterName}".`
+            );
+          }
+
+          return offchainVotesDataABI;
+
+        case VotingAdapterName.VotingContract:
+          const {default: lazyVotingABI} = await import(
+            '../../../truffle-contracts/VotingContract.json'
+          );
+
+          const votingVotesDataABI = (lazyVotingABI as AbiItem[]).find(
+            (ai) => ai.name === 'votes'
+          );
+
+          if (!votingVotesDataABI) {
+            throw new Error(
+              `No "votes" function ABI was found for "${votingAdapterName}".`
+            );
+          }
+
+          return votingVotesDataABI;
+
+        default:
+          throw new Error(
+            `No voting adapter name was found for "${votingAdapterName}".`
+          );
+      }
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  return {
+    proposalsVotes,
+    proposalsVotesError,
+    proposalsVotesStatus,
+  };
+}

--- a/src/components/proposals/hooks/useProposalsVotes.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.ts
@@ -163,8 +163,6 @@ export function useProposalsVotes(
         web3Instance,
       });
 
-      console.log('votesDataResults', votesDataResults);
-
       setProposalsVotesStatus(AsyncStatus.FULFILLED);
       setProposaslsVotes(
         proposalIds.map((id, i) => [

--- a/src/components/proposals/hooks/useProposalsVotes.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.ts
@@ -83,7 +83,7 @@ export function useProposalsVotes(
    */
 
   async function getProposalsVotesOnchain() {
-    if (!registryAddress || !registryABI) {
+    if (!registryAddress || !registryABI || !proposalIds.length) {
       return;
     }
 

--- a/src/components/proposals/hooks/useProposalsVotes.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.unit.test.ts
@@ -511,6 +511,107 @@ describe('useProposalsVotes unit tests', () => {
     });
   });
 
+  test('should return correct data when no bytes32[] proposal ids', async () => {
+    // Internal filtering will cause the resulting array to be empty.
+    const proposalIds = ['bad', 'erg', 'meow'];
+
+    await act(async () => {
+      const {result, waitForNextUpdate} = await renderHook(
+        () => useProposalsVotes(proposalIds),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                DEFAULT_ETH_ADDRESS
+              );
+
+              // @note Setting a bad voting adapter name to cause an error
+              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.OffchainVotingContract
+              );
+
+              /**
+               * @note Maintain the same order as the contract's struct.
+               */
+              const offchainVotesDataResponse = web3Instance.eth.abi.encodeParameter(
+                {
+                  Voting: {
+                    snapshot: 'uint256',
+                    proposalHash: 'bytes32',
+                    reporter: 'address',
+                    resultRoot: 'bytes32',
+                    nbVoters: 'uint256',
+                    nbYes: 'uint256',
+                    nbNo: 'uint256',
+                    index: 'uint256',
+                    startingTime: 'uint256',
+                    gracePeriodStartingTime: 'uint256',
+                    isChallenged: 'bool',
+                    fallbackVotesCount: 'uint256',
+                  },
+                },
+                {
+                  snapshot: '8376297',
+                  proposalHash: DEFAULT_PROPOSAL_HASH,
+                  reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+                  resultRoot:
+                    '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+                  nbVoters: '0',
+                  nbYes: '1',
+                  nbNo: '0',
+                  index: '0',
+                  startingTime: '1617878162',
+                  gracePeriodStartingTime: '1617964640',
+                  isChallenged: false,
+                  fallbackVotesCount: '0',
+                }
+              );
+
+              // Mock `dao.votingAdapter` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotingAdapterResponse]]
+                )
+              );
+
+              // Mock `IVoting.getAdapterName` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotingAdapterNameResponse]]
+                )
+              );
+
+              // Mock votes data responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotesDataResponse]]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.STANDBY);
+      expect(result.current.proposalsVotesError).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([]);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.FULFILLED);
+      expect(result.current.proposalsVotesError).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([]);
+    });
+  });
+
   test('should return correct data when no proposal ids', async () => {
     // Internal filtering will cause the resulting array to be empty.
     const proposalIds = [''];

--- a/src/components/proposals/hooks/useProposalsVotes.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.unit.test.ts
@@ -1,0 +1,614 @@
+import {act, renderHook} from '@testing-library/react-hooks';
+
+import {
+  DEFAULT_ETH_ADDRESS,
+  DEFAULT_PROPOSAL_HASH,
+} from '../../../test/helpers';
+import {AsyncStatus} from '../../../util/types';
+import {useProposalsVotes} from './useProposalsVotes';
+import Wrapper from '../../../test/Wrapper';
+import {VotingAdapterName} from '../../adapters-extensions/enums';
+
+describe('useProposalsVotes unit tests', () => {
+  test('should return correct data when OK', async () => {
+    const proposalIds = [
+      '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+      '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca76',
+      '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca77',
+    ];
+
+    await act(async () => {
+      const {result, waitForNextUpdate} = await renderHook(
+        () => useProposalsVotes(proposalIds),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                DEFAULT_ETH_ADDRESS
+              );
+              const votingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                '0xa8ED02b24B4E9912e39337322885b65b23CdF188'
+              );
+
+              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.OffchainVotingContract
+              );
+
+              const votingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.VotingContract
+              );
+
+              /**
+               * @note Maintain the same order as the contract's struct.
+               * @note We use the same, single result for any off-chain votes repsonses for testing only.
+               */
+              const offchainVotesDataResponse = web3Instance.eth.abi.encodeParameter(
+                {
+                  Voting: {
+                    snapshot: 'uint256',
+                    proposalHash: 'bytes32',
+                    reporter: 'address',
+                    resultRoot: 'bytes32',
+                    nbVoters: 'uint256',
+                    nbYes: 'uint256',
+                    nbNo: 'uint256',
+                    index: 'uint256',
+                    startingTime: 'uint256',
+                    gracePeriodStartingTime: 'uint256',
+                    isChallenged: 'bool',
+                    fallbackVotesCount: 'uint256',
+                  },
+                },
+                {
+                  snapshot: '8376297',
+                  proposalHash: DEFAULT_PROPOSAL_HASH,
+                  reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+                  resultRoot:
+                    '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+                  nbVoters: '0',
+                  nbYes: '1',
+                  nbNo: '0',
+                  index: '0',
+                  startingTime: '1617878162',
+                  gracePeriodStartingTime: '1617964640',
+                  isChallenged: false,
+                  fallbackVotesCount: '0',
+                }
+              );
+
+              /**
+               * @note Maintain the same order as the contract's struct.
+               */
+              const onchainVotesDataResponse = web3Instance.eth.abi.encodeParameter(
+                {
+                  Voting: {
+                    nbYes: 'uint256',
+                    nbNo: 'uint256',
+                    startingTime: 'uint256',
+                    blockNumber: 'uint256',
+                  },
+                },
+                {
+                  blockNumber: '10',
+                  nbNo: '50',
+                  nbYes: '100',
+                  startingTime: '1617878162',
+                }
+              );
+
+              // Mock `dao.votingAdapter` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      offchainVotingAdapterResponse,
+                      offchainVotingAdapterResponse,
+                      votingAdapterResponse,
+                    ],
+                  ]
+                )
+              );
+
+              // Mock `IVoting.getAdapterName` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      offchainVotingAdapterNameResponse,
+                      offchainVotingAdapterNameResponse,
+                      votingAdapterNameResponse,
+                    ],
+                  ]
+                )
+              );
+
+              // Mock votes data responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      offchainVotesDataResponse,
+                      offchainVotesDataResponse,
+                      onchainVotesDataResponse,
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.STANDBY);
+      expect(result.current.proposalsVotesError).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([]);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.PENDING);
+      expect(result.current.proposalsVotesError).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([]);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.FULFILLED);
+      expect(result.current.proposalsVotesError).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([
+        [
+          '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+          {
+            OffchainVotingContract: {
+              '0': '8376297',
+              '1':
+                '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+              '10': false,
+              '11': '0',
+              '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+              '3':
+                '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+              '4': '0',
+              '5': '1',
+              '6': '0',
+              '7': '0',
+              '8': '1617878162',
+              '9': '1617964640',
+              __length__: 12,
+              fallbackVotesCount: '0',
+              gracePeriodStartingTime: '1617964640',
+              index: '0',
+              isChallenged: false,
+              nbNo: '0',
+              nbVoters: '0',
+              nbYes: '1',
+              proposalHash:
+                '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+              reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+              resultRoot:
+                '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+              snapshot: '8376297',
+              startingTime: '1617878162',
+            },
+          },
+        ],
+        [
+          '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca76',
+          {
+            OffchainVotingContract: {
+              '0': '8376297',
+              '1':
+                '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+              '10': false,
+              '11': '0',
+              '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+              '3':
+                '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+              '4': '0',
+              '5': '1',
+              '6': '0',
+              '7': '0',
+              '8': '1617878162',
+              '9': '1617964640',
+              __length__: 12,
+              fallbackVotesCount: '0',
+              gracePeriodStartingTime: '1617964640',
+              index: '0',
+              isChallenged: false,
+              nbNo: '0',
+              nbVoters: '0',
+              nbYes: '1',
+              proposalHash:
+                '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+              reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+              resultRoot:
+                '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+              snapshot: '8376297',
+              startingTime: '1617878162',
+            },
+          },
+        ],
+        [
+          '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca77',
+          {
+            VotingContract: {
+              '0': '100',
+              '1': '50',
+              '2': '1617878162',
+              '3': '10',
+              __length__: 4,
+              blockNumber: '10',
+              nbNo: '50',
+              nbYes: '100',
+              startingTime: '1617878162',
+            },
+          },
+        ],
+      ]);
+    });
+  });
+
+  test('should return correct data on bad voting adapter name', async () => {
+    const proposalIds = [DEFAULT_PROPOSAL_HASH];
+
+    await act(async () => {
+      const {result, waitForNextUpdate} = await renderHook(
+        () => useProposalsVotes(proposalIds),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                DEFAULT_ETH_ADDRESS
+              );
+
+              // @note Setting a bad voting adapter name to cause an error
+              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                'BadVotingAdapterName'
+              );
+
+              /**
+               * @note Maintain the same order as the contract's struct.
+               * @note We use the same, single result for any off-chain votes repsonses for testing only.
+               */
+              const offchainVotesDataResponse = web3Instance.eth.abi.encodeParameter(
+                {
+                  Voting: {
+                    snapshot: 'uint256',
+                    proposalHash: 'bytes32',
+                    reporter: 'address',
+                    resultRoot: 'bytes32',
+                    nbVoters: 'uint256',
+                    nbYes: 'uint256',
+                    nbNo: 'uint256',
+                    index: 'uint256',
+                    startingTime: 'uint256',
+                    gracePeriodStartingTime: 'uint256',
+                    isChallenged: 'bool',
+                    fallbackVotesCount: 'uint256',
+                  },
+                },
+                {
+                  snapshot: '8376297',
+                  proposalHash: DEFAULT_PROPOSAL_HASH,
+                  reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+                  resultRoot:
+                    '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+                  nbVoters: '0',
+                  nbYes: '1',
+                  nbNo: '0',
+                  index: '0',
+                  startingTime: '1617878162',
+                  gracePeriodStartingTime: '1617964640',
+                  isChallenged: false,
+                  fallbackVotesCount: '0',
+                }
+              );
+
+              // Mock `dao.votingAdapter` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotingAdapterResponse]]
+                )
+              );
+
+              // Mock `IVoting.getAdapterName` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotingAdapterNameResponse]]
+                )
+              );
+
+              // Mock votes data responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotesDataResponse]]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.STANDBY);
+      expect(result.current.proposalsVotesError).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([]);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.PENDING);
+      expect(result.current.proposalsVotesError).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([]);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.REJECTED);
+      expect(result.current.proposalsVotesError?.message).toMatch(
+        /no voting adapter name was found for "badvotingadaptername"/i
+      );
+      expect(result.current.proposalsVotes).toMatchObject([]);
+    });
+  });
+
+  test('should only return data for hex proposal ids', async () => {
+    const proposalIds = ['badId', DEFAULT_PROPOSAL_HASH];
+
+    await act(async () => {
+      const {result, waitForNextUpdate} = await renderHook(
+        () => useProposalsVotes(proposalIds),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                DEFAULT_ETH_ADDRESS
+              );
+
+              // @note Setting a bad voting adapter name to cause an error
+              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.OffchainVotingContract
+              );
+
+              /**
+               * @note Maintain the same order as the contract's struct.
+               */
+              const offchainVotesDataResponse = web3Instance.eth.abi.encodeParameter(
+                {
+                  Voting: {
+                    snapshot: 'uint256',
+                    proposalHash: 'bytes32',
+                    reporter: 'address',
+                    resultRoot: 'bytes32',
+                    nbVoters: 'uint256',
+                    nbYes: 'uint256',
+                    nbNo: 'uint256',
+                    index: 'uint256',
+                    startingTime: 'uint256',
+                    gracePeriodStartingTime: 'uint256',
+                    isChallenged: 'bool',
+                    fallbackVotesCount: 'uint256',
+                  },
+                },
+                {
+                  snapshot: '8376297',
+                  proposalHash: DEFAULT_PROPOSAL_HASH,
+                  reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+                  resultRoot:
+                    '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+                  nbVoters: '0',
+                  nbYes: '1',
+                  nbNo: '0',
+                  index: '0',
+                  startingTime: '1617878162',
+                  gracePeriodStartingTime: '1617964640',
+                  isChallenged: false,
+                  fallbackVotesCount: '0',
+                }
+              );
+
+              // Mock `dao.votingAdapter` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotingAdapterResponse]]
+                )
+              );
+
+              // Mock `IVoting.getAdapterName` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotingAdapterNameResponse]]
+                )
+              );
+
+              // Mock votes data responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotesDataResponse]]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.STANDBY);
+      expect(result.current.proposalsVotesError).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([]);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.PENDING);
+      expect(result.current.proposalsVotesError).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([]);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.FULFILLED);
+      expect(result.current.proposalsVotesError?.message).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([
+        [
+          '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+          {
+            OffchainVotingContract: {
+              '0': '8376297',
+              '1':
+                '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+              '10': false,
+              '11': '0',
+              '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+              '3':
+                '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+              '4': '0',
+              '5': '1',
+              '6': '0',
+              '7': '0',
+              '8': '1617878162',
+              '9': '1617964640',
+              __length__: 12,
+              fallbackVotesCount: '0',
+              gracePeriodStartingTime: '1617964640',
+              index: '0',
+              isChallenged: false,
+              nbNo: '0',
+              nbVoters: '0',
+              nbYes: '1',
+              proposalHash:
+                '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+              reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+              resultRoot:
+                '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+              snapshot: '8376297',
+              startingTime: '1617878162',
+            },
+          },
+        ],
+      ]);
+    });
+  });
+
+  test('should return correct data when no proposal ids', async () => {
+    // Internal filtering will cause the resulting array to be empty.
+    const proposalIds = [''];
+
+    await act(async () => {
+      const {result, waitForNextUpdate} = await renderHook(
+        () => useProposalsVotes(proposalIds),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                DEFAULT_ETH_ADDRESS
+              );
+
+              // @note Setting a bad voting adapter name to cause an error
+              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.OffchainVotingContract
+              );
+
+              /**
+               * @note Maintain the same order as the contract's struct.
+               */
+              const offchainVotesDataResponse = web3Instance.eth.abi.encodeParameter(
+                {
+                  Voting: {
+                    snapshot: 'uint256',
+                    proposalHash: 'bytes32',
+                    reporter: 'address',
+                    resultRoot: 'bytes32',
+                    nbVoters: 'uint256',
+                    nbYes: 'uint256',
+                    nbNo: 'uint256',
+                    index: 'uint256',
+                    startingTime: 'uint256',
+                    gracePeriodStartingTime: 'uint256',
+                    isChallenged: 'bool',
+                    fallbackVotesCount: 'uint256',
+                  },
+                },
+                {
+                  snapshot: '8376297',
+                  proposalHash: DEFAULT_PROPOSAL_HASH,
+                  reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+                  resultRoot:
+                    '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+                  nbVoters: '0',
+                  nbYes: '1',
+                  nbNo: '0',
+                  index: '0',
+                  startingTime: '1617878162',
+                  gracePeriodStartingTime: '1617964640',
+                  isChallenged: false,
+                  fallbackVotesCount: '0',
+                }
+              );
+
+              // Mock `dao.votingAdapter` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotingAdapterResponse]]
+                )
+              );
+
+              // Mock `IVoting.getAdapterName` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotingAdapterNameResponse]]
+                )
+              );
+
+              // Mock votes data responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotesDataResponse]]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.STANDBY);
+      expect(result.current.proposalsVotesError).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([]);
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.FULFILLED);
+      expect(result.current.proposalsVotesError).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([]);
+    });
+  });
+});

--- a/src/components/proposals/hooks/useProposalsVotingState.ts
+++ b/src/components/proposals/hooks/useProposalsVotingState.ts
@@ -94,6 +94,15 @@ export function useProposalsVotingState(
       return;
     }
 
+    // Only use hex (more specifically `bytes32`) id's
+    const safeProposalIds = proposalIds.filter(web3Instance.utils.isHexStrict);
+
+    if (!safeProposalIds.length) {
+      setProposalsVotingStateStatus(AsyncStatus.FULFILLED);
+
+      return;
+    }
+
     try {
       const votingResultAbi = votingABI.find((ai) => ai.name === 'voteResult');
 
@@ -103,7 +112,7 @@ export function useProposalsVotingState(
         );
       }
 
-      const calls: MulticallTuple[] = proposalIds.map((id) => [
+      const calls: MulticallTuple[] = safeProposalIds.map((id) => [
         votingAddress,
         votingResultAbi,
         [registryAddress, id],
@@ -118,7 +127,7 @@ export function useProposalsVotingState(
 
       setProposalsVotingStateStatus(AsyncStatus.FULFILLED);
       setProposaslsVotingState(
-        proposalIds.map((id, i) => [id, proposalsVotingStateResult[i]])
+        safeProposalIds.map((id, i) => [id, proposalsVotingStateResult[i]])
       );
     } catch (error) {
       setProposalsVotingStateStatus(AsyncStatus.REJECTED);

--- a/src/components/proposals/hooks/useProposalsVotingState.unit.test.tsx
+++ b/src/components/proposals/hooks/useProposalsVotingState.unit.test.tsx
@@ -100,7 +100,7 @@ describe('useProposalsVotingState unit tests', () => {
     });
   });
 
-  test('should throw if bad proposalIds not bytes32[]', async () => {
+  test('should return empty result if every proposalIds is not bytes32[]', async () => {
     const badProposalIds = ['abc123', 'abc456'];
 
     await act(async () => {
@@ -162,12 +162,10 @@ describe('useProposalsVotingState unit tests', () => {
       await waitForNextUpdate();
 
       expect(result.current.proposalsVotingStateStatus).toBe(
-        AsyncStatus.REJECTED
+        AsyncStatus.FULFILLED
       );
 
-      expect(
-        result.current.proposalsVotingStateError?.message.length
-      ).toBeGreaterThan(0);
+      expect(result.current.proposalsVotingStateError).toBe(undefined);
       expect(result.current.proposalsVotingState).toMatchObject([]);
     });
   });

--- a/src/components/proposals/types.ts
+++ b/src/components/proposals/types.ts
@@ -139,6 +139,41 @@ export type ProposalOrDraftSignDataFromType<
 > = T extends SnapshotType.proposal ? SnapshotProposalData : SnapshotDraftData;
 
 /**
+ * Voting.sol->Voting
+ *
+ * @link https://github.com/openlawteam/molochv3-contracts/blob/master/contracts/adapters/voting/Voting.sol
+ */
+export type VotingAdapterVotes = {
+  nbYes: string;
+  nbNo: string;
+  startingTime: string;
+  blockNumber: string;
+  // {[address]: vote index}
+  votes: Record<string, string>;
+};
+
+/**
+ * OffchainVoting.sol->Voting
+ *
+ * @link https://github.com/openlawteam/molochv3-contracts/blob/master/contracts/adapters/voting/OffchainVoting.sol
+ */
+export type OffchainVotingAdapterVotes = {
+  snapshot: string;
+  proposalHash: string;
+  reporter: string;
+  resultRoot: string;
+  nbYes: string;
+  nbNo: string;
+  index: string;
+  startingTime: string;
+  gracePeriodStartingTime: string;
+  isChallenged: boolean;
+  // {[address]: boolean}
+  fallbackVotes: Record<string, boolean>;
+  fallbackVotesCount: string;
+};
+
+/**
  * VotingResult
  *
  * A custom result we build to deliver to components.

--- a/src/components/proposals/types.ts
+++ b/src/components/proposals/types.ts
@@ -144,12 +144,10 @@ export type ProposalOrDraftSignDataFromType<
  * @link https://github.com/openlawteam/molochv3-contracts/blob/master/contracts/adapters/voting/Voting.sol
  */
 export type VotingAdapterVotes = {
-  nbYes: string;
-  nbNo: string;
-  startingTime: string;
   blockNumber: string;
-  // {[address]: vote index}
-  votes: Record<string, string>;
+  nbNo: string;
+  nbYes: string;
+  startingTime: string;
 };
 
 /**
@@ -158,19 +156,17 @@ export type VotingAdapterVotes = {
  * @link https://github.com/openlawteam/molochv3-contracts/blob/master/contracts/adapters/voting/OffchainVoting.sol
  */
 export type OffchainVotingAdapterVotes = {
-  snapshot: string;
+  fallbackVotesCount: string;
+  gracePeriodStartingTime: string;
+  index: string;
+  isChallenged: boolean;
+  nbNo: string;
+  nbYes: string;
   proposalHash: string;
   reporter: string;
   resultRoot: string;
-  nbYes: string;
-  nbNo: string;
-  index: string;
+  snapshot: string;
   startingTime: string;
-  gracePeriodStartingTime: string;
-  isChallenged: boolean;
-  // {[address]: boolean}
-  fallbackVotes: Record<string, boolean>;
-  fallbackVotesCount: string;
 };
 
 /**


### PR DESCRIPTION
Fixes #227 

🥳 **Adds**

 - `useProposalsVotes` hook to get mapped votes data from each proposal's adapter
 - Unit tests for `useProposalsVotes`

✨ **Updates**

 - `Proposals` now uses `useProposalsVotes` hook to get votes data for each proposal based on the proposal's voting adapter.
 - Unit tests for `Proposals` to mock responses for `useProposalsVotes`
 - `useProposalsVotingState` now checks for case when there are no `bytes32[]` voting ids
 - Unit tests for `useProposalsVotingState` when no `bytes32[]` voting ids
 - Removes an expression from check for no proposals to be a bit looser.
 
🐞 **Bugs squashed**

 - Proposals which used off-chain voting should now be listed in correct category when voting ends (e.g. `/membership` page).
