### PR TITLE
Updates how an active member is determined

### DIFF
--- a/src/components/proposals/hooks/useOffchainVotingResults.unit.test.ts
+++ b/src/components/proposals/hooks/useOffchainVotingResults.unit.test.ts
@@ -165,14 +165,6 @@ describe('useOffchainVotingResults unit tests', () => {
       expect(result.current).toMatchObject({
         offchainVotingResults: [],
         offchainVotingResultsError: undefined,
-        offchainVotingResultsStatus: 'STANDBY',
-      });
-
-      await waitForNextUpdate();
-
-      expect(result.current).toMatchObject({
-        offchainVotingResults: [],
-        offchainVotingResultsError: undefined,
         offchainVotingResultsStatus: 'PENDING',
       });
 

--- a/src/components/web3/hooks/useWeb3ModalManager.ts
+++ b/src/components/web3/hooks/useWeb3ModalManager.ts
@@ -1,8 +1,10 @@
 import {useReducer, useCallback, useEffect} from 'react';
+import {useDispatch} from 'react-redux';
 import Web3 from 'web3';
 import Web3Modal from 'web3modal';
 
 import {DEFAULT_CHAIN} from '../../../config';
+import {clearConnectedMember} from '../../../store/actions';
 import {NetworkNames, NetworkIDs} from '../../../util/enums';
 
 type NetworkNameType = NetworkNames;
@@ -124,6 +126,12 @@ export default function useWeb3ModalManager({
   const getNetworkNameCached = useCallback(getNetworkName, [web3ModalChain]);
 
   /**
+   * Their hooks
+   */
+
+  const storeDispatch = useDispatch();
+
+  /**
    * Init Web3Modal
    */
   useEffect(() => {
@@ -215,6 +223,7 @@ export default function useWeb3ModalManager({
 
       // Reset all states; except for web3Modal?!
       dispatch({type: ActionType.DEACTIVATE_PROVIDER});
+      storeDispatch(clearConnectedMember());
     } catch (error) {
       console.error(error);
     }

--- a/src/store/connectedMember/actions.ts
+++ b/src/store/connectedMember/actions.ts
@@ -2,8 +2,9 @@ import {Dispatch} from 'redux';
 
 import {BURN_ADDRESS} from '../../util/constants';
 import {ConnectedMemberState} from '../connectedMember/types';
-import {ContractsStateEntry} from '../contracts/types';
 import {normalizeString} from '../../util/helpers';
+import {SHARES_ADDRESS} from '../../config';
+import {StoreState} from '../types';
 
 export const SET_CONNECTED_MEMBER = 'SET_CONNECTED_MEMBER';
 export const CLEAR_CONNECTED_MEMBER = 'CLEAR_CONNECTED_MEMBER';
@@ -19,27 +20,32 @@ export const CLEAR_CONNECTED_MEMBER = 'CLEAR_CONNECTED_MEMBER';
  * is to ensure we're not too restrictive in our Dapp logic and
  * letting the contract do its job.
  */
-export function getConnectedMember(
-  account: string,
-  daoRegistryContract: ContractsStateEntry
-) {
-  return async function (dispatch: Dispatch<any>) {
-    const daoRegistryInstance = daoRegistryContract.instance;
+export function getConnectedMember(account: string) {
+  return async function (dispatch: Dispatch<any>, getState: () => StoreState) {
+    const daoRegistryMethods = getState().contracts.DaoRegistryContract
+      ?.instance.methods;
+    const bankExtensionMethods = getState().contracts.BankExtensionContract
+      ?.instance.methods;
 
-    if (!daoRegistryInstance || !account) {
+    if (!daoRegistryMethods || !bankExtensionMethods || !account) {
       dispatch(clearConnectedMember());
 
       return;
     }
 
     try {
-      const memberAddressByDelegateKey: string = await daoRegistryInstance.methods
+      const memberAddressByDelegateKey: string = await daoRegistryMethods
         .memberAddressesByDelegatedKey(account)
         .call({from: account});
-      const isActiveMember: boolean = await daoRegistryInstance.methods
-        .isActiveMember(memberAddressByDelegateKey)
-        .call({from: account});
-      const currentDelegateKey: string = await daoRegistryInstance.methods
+
+      const isActiveMember: boolean =
+        Number(
+          await bankExtensionMethods
+            .balanceOf(memberAddressByDelegateKey, SHARES_ADDRESS)
+            .call({from: account})
+        ) > 0;
+
+      const currentDelegateKey: string = await daoRegistryMethods
         .getCurrentDelegateKey(memberAddressByDelegateKey)
         .call({from: account});
 

--- a/src/test/Wrapper.tsx
+++ b/src/test/Wrapper.tsx
@@ -13,8 +13,8 @@ import {
   Web3ModalContextValue,
 } from '../components/web3/Web3ModalManager';
 import {
+  balanceOfMember,
   getCurrentDelegateKey,
-  isActiveMember,
   memberAddressesByDelegatedKey,
 } from './web3Responses';
 import {CHAINS as mockChains} from '../config';
@@ -172,7 +172,8 @@ export default function Wrapper(
       mockWeb3Provider.injectResult(
         ...memberAddressesByDelegatedKey({web3Instance})
       );
-      mockWeb3Provider.injectResult(...isActiveMember({web3Instance}));
+      // Defaults to `100`
+      mockWeb3Provider.injectResult(...balanceOfMember({web3Instance}));
       mockWeb3Provider.injectResult(...getCurrentDelegateKey({web3Instance}));
     }
   }, [mockWeb3Provider, useInit, useWallet, web3Instance]);

--- a/src/test/web3Responses/member.ts
+++ b/src/test/web3Responses/member.ts
@@ -1,6 +1,7 @@
 import {DEFAULT_ETH_ADDRESS} from '../helpers';
 import {TestWeb3ResponseArgs, TestWeb3ResponseReturn} from './types';
 import DAORegistryABI from '../../truffle-contracts/DaoRegistry.json';
+import BankExtensionABI from '../../truffle-contracts/BankExtension.json';
 
 /**
  * memberAddressesByDelegatedKey
@@ -17,5 +18,24 @@ export const memberAddressesByDelegatedKey = ({
     result ??
       web3Instance.eth.abi.encodeParameter('address', DEFAULT_ETH_ADDRESS),
     {abiMethodName: 'memberAddressesByDelegatedKey', abi: DAORegistryABI},
+  ];
+};
+
+/**
+ * balanceOfMember
+ *
+ * Mocks result for `bank.balanceOf(member, tokenAddr)`.
+ *
+ * @param web3Instance
+ * @returns {TestWeb3ResponseReturn<string>}
+ * @link https://github.com/openlawteam/molochv3-contracts/blob/master/contracts/extensions/bank/Bank.sol
+ */
+export const balanceOfMember = ({
+  result,
+  web3Instance,
+}: TestWeb3ResponseArgs): TestWeb3ResponseReturn<string> => {
+  return [
+    result ?? web3Instance.eth.abi.encodeParameter('uint160', 100),
+    {abiMethodName: 'balanceOf', abi: BankExtensionABI},
   ];
 };


### PR DESCRIPTION
Fixes #236 

🥳 **Adds**

- Test suite: `balanceOfMember` mock response for web3

✨ **Updates**

 - Active member is now determined by using `bank.balanceOf > 0` in `getConnectedMember`
 - `Init` effect dependencies include DAO registry methods and bank methods
 - Function signature changes for `Init-> handleGetMember`
 - `useOffchainVotingResults` unit test updated to reflect changes in `Init`
 - `useWeb3ModalManager` now calls `clearConnectedMember` on wallet disconnect
 - Updates test suite and some unit tests to reflect changes in how membership is determined