### PR TITLE
remove loot from members listing components

### DIFF
--- a/src/gql/queryMembers.ts
+++ b/src/gql/queryMembers.ts
@@ -9,7 +9,6 @@ export const GET_MEMBERS = gql`
         delegateKey
         isDelegated
         shares
-        loot
         didFullyRagequit
       }
     }

--- a/src/pages/members/types.ts
+++ b/src/pages/members/types.ts
@@ -8,5 +8,4 @@ export type Member = {
   delegateKey: string;
   isDelegated: boolean;
   shares: string;
-  loot: string;
 };


### PR DESCRIPTION
Fixes #238 

✨ **Updates**

 - use member delegated key to check `SHARES` balance for members listing

⛔️ **Removes**

 - `LOOT`-related queries and calls for determining members in members listing
