### PR TITLE
Allows anyone to process a proposal

### DIFF
--- a/src/components/proposals/ProcessAction.tsx
+++ b/src/components/proposals/ProcessAction.tsx
@@ -25,6 +25,17 @@ type ProcessActionProps = {
   proposal: ProposalData;
 };
 
+/**
+ * Cached outside the component to prevent infinite re-renders.
+ *
+ * The same can be accomplished inside the component using
+ * `useState`, `useRef`, etc., depending on the use case.
+ */
+const useMemberActionDisabledProps = {
+  // Anyone can process a proposal - it's just a question of gas payment.
+  skipIsActiveMemberCheck: true,
+};
+
 export default function ProcessAction(props: ProcessActionProps) {
   const {
     disabled: propsDisabled,
@@ -58,7 +69,7 @@ export default function ProcessAction(props: ProcessActionProps) {
     isDisabled,
     openWhyDisabledModal,
     WhyDisabledModal,
-  } = useMemberActionDisabled();
+  } = useMemberActionDisabled(useMemberActionDisabledProps);
 
   const gasPrices = useETHGasPrice();
 

--- a/src/hooks/useMemberActionDisabled.tsx
+++ b/src/hooks/useMemberActionDisabled.tsx
@@ -7,6 +7,19 @@ import {useWeb3Modal} from '../components/web3/hooks';
 import FadeIn from '../components/common/FadeIn';
 import TimesSVG from '../assets/svg/TimesSVG';
 
+/**
+ * Props should be cached somehow to prevent a new object
+ * making the hook re-render each time the parent re-renders,
+ * causing a continuous loop.
+ */
+type UseMemberActionDisabledProps = {
+  /**
+   * Allows the active member check to be skipped.
+   * e.g. A tx does not require the account to be a member.
+   */
+  skipIsActiveMemberCheck?: boolean;
+};
+
 type UseMemberActionDisabledReturn = {
   disabledReason: string;
   isDisabled: boolean;
@@ -28,7 +41,11 @@ type WhyDisabledModalProps = {
  * @param {ProposalActionWhyDisabledProps} props
  * @returns {UseMemberActionDisabledReturn}
  */
-export function useMemberActionDisabled(): UseMemberActionDisabledReturn {
+export function useMemberActionDisabled(
+  props?: UseMemberActionDisabledProps
+): UseMemberActionDisabledReturn {
+  const {skipIsActiveMemberCheck = false} = props || {};
+
   /**
    * State
    */
@@ -59,9 +76,9 @@ export function useMemberActionDisabled(): UseMemberActionDisabledReturn {
   // Get the first index of other reasons.
   const otherReasonNext =
     otherDisabledReasons && otherDisabledReasons.find((r) => r);
-  const isDisabled =
-    !connected || !isActiveMember || (otherReasonNext ? true : false);
   const disabledReason = getDisabledReason();
+  const isDisabled =
+    (disabledReason ? true : false) || (otherReasonNext ? true : false);
   const canShowDisabledReason = isDisabled && disabledReason ? true : false;
 
   /**
@@ -92,7 +109,7 @@ export function useMemberActionDisabled(): UseMemberActionDisabledReturn {
       return 'Your wallet is not connected.';
     }
 
-    if (!isActiveMember) {
+    if (!isActiveMember && !skipIsActiveMemberCheck) {
       return 'Either you are not a member, or your membership is not active.';
     }
 

--- a/src/hooks/useMemberActionDisabled.unit.test.ts
+++ b/src/hooks/useMemberActionDisabled.unit.test.ts
@@ -101,6 +101,53 @@ describe('useMemberActionDisabled unit tests', () => {
     expect(result.current.setOtherDisabledReasons).toBeInstanceOf(Function);
   });
 
+  test('should skip member check when "props.skipIsActiveMemberCheck" is "true"', async () => {
+    await act(async () => {
+      let reduxStore: any;
+
+      // @note By default <Wrapper /> set the member to active when using `useWallet`
+      const {result} = await renderHook(
+        () => useMemberActionDisabled({skipIsActiveMemberCheck: true}),
+        {
+          initialProps: {
+            getProps: ({store}) => {
+              reduxStore = store;
+            },
+            useInit: true,
+            useWallet: true,
+          },
+          wrapper: Wrapper,
+        }
+      );
+
+      // Assert initial state
+      expect(result.current.isDisabled).toBe(false);
+      expect(result.current.disabledReason).toMatch('');
+      expect(result.current.openWhyDisabledModal).toBeInstanceOf(Function);
+      expect(result.current.WhyDisabledModal).toBeInstanceOf(Function);
+      expect(result.current.setOtherDisabledReasons).toBeInstanceOf(Function);
+
+      await waitFor(() => {
+        expect(reduxStore.getState().connectedMember).not.toBeNull();
+      });
+
+      reduxStore.dispatch({
+        type: SET_CONNECTED_MEMBER,
+        ...reduxStore.getState().connectedMember,
+        isActiveMember: false,
+      });
+
+      // await waitForNextUpdate();
+
+      // Assert post-init state
+      expect(result.current.isDisabled).toBe(false);
+      expect(result.current.disabledReason).toBe('');
+      expect(result.current.openWhyDisabledModal).toBeInstanceOf(Function);
+      expect(result.current.WhyDisabledModal).toBeInstanceOf(Function);
+      expect(result.current.setOtherDisabledReasons).toBeInstanceOf(Function);
+    });
+  });
+
   test('should return correct data when other reason is set', async () => {
     // @note By default <Wrapper /> set the member to active when using `useWallet`
     const {result, waitForNextUpdate} = renderHook(


### PR DESCRIPTION
Fixes #239 

✨ **Updates**

 - `useMemberActionDisabled`: Adds `skipIsActiveMemberCheck: boolean` prop
 - `useMemberActionDisabled`: Improves logic when setting `isDisabled`
 - Updates `useMemberActionDisabled` unit tests
 - `ProcessAction` now skips checking if the member is active
 
🐞 **Bugs squashed**

 - Anyone can now process a proposal just like they can in the contract directly


