### PR TITLE
fix conditional for members list

### DIFF
--- a/src/pages/members/hooks/useMembers.ts
+++ b/src/pages/members/hooks/useMembers.ts
@@ -180,7 +180,7 @@ export default function useMembers(): UseMembersReturn {
 
       const nbMembers = await daoRegistryMethods.getNbMembers().call();
 
-      if (Number(nbMembers) > 1) {
+      if (Number(nbMembers) > 0) {
         // Build calls to get list of member addresses
         const getMemberAddressABI = daoRegistryABI.find(
           (item) => item.name === 'getMemberAddress'


### PR DESCRIPTION
✨ **Updates**

 - number used in conditional to get list of members (This didn't cause a bug before because the DAO is always created with more than 1 member when initialized from the DAO factory. But this change is more accurate to get the list of members.)
 
