### PR TITLE
Get voting information via proposal's voting adapter (not DAO's)

### DIFF
--- a/src/App.unit.test.tsx
+++ b/src/App.unit.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {screen, render, waitFor} from '@testing-library/react';
 import {useHistory} from 'react-router-dom';
 

--- a/src/components/governance/GovernanceProposalsList.tsx
+++ b/src/components/governance/GovernanceProposalsList.tsx
@@ -38,7 +38,6 @@ type FilteredProposals = {
   votingProposals: ProposalData[];
 };
 
-// @todo Pass `VotingResult` down to `OffchainVotingStatus` via `ProposalCard`
 export default function GovernanceProposalsList(
   props: GovernanceProposalsListProps
 ): JSX.Element {

--- a/src/components/governance/GovernanceProposalsList.tsx
+++ b/src/components/governance/GovernanceProposalsList.tsx
@@ -3,6 +3,7 @@ import React, {Fragment, useEffect, useState} from 'react';
 import {AsyncStatus} from '../../util/types';
 import {BURN_ADDRESS} from '../../util/constants';
 import {normalizeString} from '../../util/helpers';
+import {OffchainVotingStatus} from '../proposals/voting';
 import {ProposalData, VotingResult} from '../proposals/types';
 import {ProposalHeaderNames} from '../../util/enums';
 import {useGovernanceProposals} from './hooks';
@@ -198,9 +199,13 @@ export default function GovernanceProposalsList(
           key={proposalId}
           name={proposalName}
           onClick={onProposalClick}
-          proposal={proposal}
           proposalOnClickId={proposalId}
-          votingResult={offchainResult}
+          renderStatus={() => (
+            <OffchainVotingStatus
+              proposal={proposal}
+              votingResult={offchainResult}
+            />
+          )}
         />
       );
     });

--- a/src/components/proposals/ProcessAction.unit.test.tsx
+++ b/src/components/proposals/ProcessAction.unit.test.tsx
@@ -1,28 +1,24 @@
-import {getByRole, render, screen, waitFor} from '@testing-library/react';
+import {render, screen, waitFor} from '@testing-library/react';
 import {Store} from 'redux';
 import Web3 from 'web3';
 
-import {
-  DEFAULT_ETH_ADDRESS,
-  DEFAULT_PROPOSAL_HASH,
-  FakeHttpProvider,
-} from '../../test/helpers';
 import {
   initContractOnboarding,
   setConnectedMember,
   SET_CONNECTED_MEMBER,
 } from '../../store/actions';
-import {ProposalData} from './types';
-import ProcessAction from './ProcessAction';
-import Wrapper from '../../test/Wrapper';
-import userEvent from '@testing-library/user-event';
-import {TX_CYCLE_MESSAGES} from '../web3/config';
 import {
   ethEstimateGas,
   ethGasPrice,
   getTransactionReceipt,
   sendTransaction,
 } from '../../test/web3Responses';
+import {DEFAULT_PROPOSAL_HASH, FakeHttpProvider} from '../../test/helpers';
+import {ProposalData} from './types';
+import {TX_CYCLE_MESSAGES} from '../web3/config';
+import ProcessAction from './ProcessAction';
+import userEvent from '@testing-library/user-event';
+import Wrapper from '../../test/Wrapper';
 
 describe('ProcessAction unit tests', () => {
   const actionId: string = '0xa8ED02b24B4E9912e39337322885b65b23CdF188';

--- a/src/components/proposals/ProposalActions.tsx
+++ b/src/components/proposals/ProposalActions.tsx
@@ -32,9 +32,26 @@ export default function ProposalActions(
 ): JSX.Element {
   const {adapterName, proposal} = props;
 
-  const votingAdapterName = useSelector(
+  /**
+   * Selectors
+   */
+
+  const daoVotingAdapterName = useSelector(
     (s: StoreState) => s.contracts.VotingContract?.adapterOrExtensionName
-  );
+  ) as VotingAdapterName | undefined;
+
+  /**
+   * Variables
+   */
+
+  // Use the proposal's voting adapter (has been sponsored), or fall back to the DAO's (not-yet-sponsored).
+  const votingAdapterName: VotingAdapterName | undefined =
+    proposal.daoProposalVotingAdapter?.votingAdapterName ||
+    daoVotingAdapterName;
+
+  /**
+   * Functions
+   */
 
   function renderActions() {
     if (!votingAdapterName) {
@@ -49,22 +66,28 @@ export default function ProposalActions(
             proposal={proposal}
           />
         );
-      // @todo On-chain Voting
-      // case VotingAdapterName.VotingContract:
-      //   return <></>
-      default:
-        const error = new Error(
-          `"${votingAdapterName}" is not a valid voting adapter name.`
-        );
 
+      // @todo On-chain Voting
+      case VotingAdapterName.VotingContract:
+        return <></>;
+
+      default:
         return (
           <ErrorMessageWithDetails
-            error={error}
+            error={
+              new Error(
+                `"${votingAdapterName}" is not a valid voting adapter name.`
+              )
+            }
             renderText="Something went wrong"
           />
         );
     }
   }
+
+  /**
+   * Render
+   */
 
   return (
     <Suspense

--- a/src/components/proposals/ProposalActions.unit.test.tsx
+++ b/src/components/proposals/ProposalActions.unit.test.tsx
@@ -1,18 +1,20 @@
 import {render, screen, waitFor} from '@testing-library/react';
 
-import * as useProposalWithOffchainVoteStatusToMock from './hooks/useProposalWithOffchainVoteStatus';
 import {
   CONTRACT_VOTING_OP_ROLLUP,
   createContractAction,
 } from '../../store/actions';
 import {ContractAdapterNames} from '../web3/types';
+import {DEFAULT_ETH_ADDRESS} from '../../test/helpers';
 import {ProposalData, ProposalFlowStatus} from './types';
+import {VotingAdapterName} from '../adapters-extensions/enums';
+import * as useProposalWithOffchainVoteStatusToMock from './hooks/useProposalWithOffchainVoteStatus';
 import ProposalActions from './ProposalActions';
 import Wrapper from '../../test/Wrapper';
 
 describe('ProposalActions component unit tests', () => {
-  // @note Will use the offchain voting adapter set via test suite <Wrapper />.
-  test('should render actions', async () => {
+  // @note Will use the dao's offchain voting adapter set via test suite <Wrapper />.
+  test('should render off-chain actions using dao voting adapter', async () => {
     const mock = jest
       .spyOn(
         useProposalWithOffchainVoteStatusToMock,
@@ -20,7 +22,6 @@ describe('ProposalActions component unit tests', () => {
       )
       .mockImplementation(() => ({
         status: ProposalFlowStatus.Sponsor,
-        transitionMessage: undefined,
         daoProposal: undefined,
         daoProposalVoteResult: undefined,
         daoProposalVotes: undefined,
@@ -35,7 +36,7 @@ describe('ProposalActions component unit tests', () => {
               snapshotDraft: {
                 msg: {
                   payload: {
-                    name: 'Good Proposal',
+                    name: 'Good Title',
                     body: 'Coolness',
                     metadata: {},
                   },
@@ -49,14 +50,68 @@ describe('ProposalActions component unit tests', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/sponsor/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: /sponsor/i})
+      ).toBeInTheDocument();
     });
 
     // Restore mock
     mock.mockRestore();
   });
 
-  // @note Will use the offchain voting adapter set via test suite <Wrapper />.
+  test('should render off-chain actions using proposal voting adapter', async () => {
+    const mock = jest
+      .spyOn(
+        useProposalWithOffchainVoteStatusToMock,
+        'useProposalWithOffchainVoteStatus'
+      )
+      .mockImplementation(() => ({
+        status: ProposalFlowStatus.OffchainVoting,
+        daoProposal: undefined,
+        daoProposalVoteResult: undefined,
+        daoProposalVotes: undefined,
+      }));
+
+    render(
+      <Wrapper useInit useWallet>
+        <ProposalActions
+          adapterName={ContractAdapterNames.onboarding}
+          proposal={
+            {
+              snapshotProposal: {
+                msg: {
+                  payload: {
+                    name: 'Another Good Title',
+                    body: 'Coolness',
+                    metadata: {},
+                  },
+                  timestamp: Date.now().toString(),
+                },
+              },
+              daoProposalVotingAdapter: {
+                votingAdapterAddress: DEFAULT_ETH_ADDRESS,
+                votingAdapterName: VotingAdapterName.OffchainVotingContract,
+              },
+            } as ProposalData
+          }
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: /vote yes/i})
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: /vote no/i})
+      ).toBeInTheDocument();
+    });
+
+    // Restore mock
+    mock.mockRestore();
+  });
+
+  // @note Will use the dao's offchain voting adapter set via test suite <Wrapper />.
   test('should render error when bad voting adapter name', async () => {
     const mock = jest
       .spyOn(
@@ -65,7 +120,6 @@ describe('ProposalActions component unit tests', () => {
       )
       .mockImplementation(() => ({
         status: ProposalFlowStatus.Sponsor,
-        transitionMessage: undefined,
         daoProposal: undefined,
         daoProposalVoteResult: undefined,
         daoProposalVotes: undefined,

--- a/src/components/proposals/ProposalCard.tsx
+++ b/src/components/proposals/ProposalCard.tsx
@@ -1,18 +1,12 @@
-import {useSelector} from 'react-redux';
 import LinesEllipsis from 'react-lines-ellipsis';
 import responsiveHOC from 'react-lines-ellipsis/lib/responsiveHOC';
 
-import {OffchainVotingStatus} from './voting';
-import {ProposalData, VotingResult} from './types';
-import {StoreState} from '../../store/types';
-import {VotingAdapterName} from '../adapters-extensions/enums';
 import {isEthAddressValid} from '../../util/validation';
 import {truncateEthAddress} from '../../util/helpers';
 
 type ProposalCardProps = {
   buttonText?: string;
   onClick: (proposalOnClickId: string) => void;
-  proposal: ProposalData;
   /**
    * The ID for the proposal to be used for navigation.
    * As there can be a few different options, it's best to provide it
@@ -21,13 +15,9 @@ type ProposalCardProps = {
   proposalOnClickId: string;
   name: string;
   /**
-   * If a fetched `VotingResult` is provided
-   * it will save the need to fetch inside of `OffchainVotingStatus`.
-   *
-   * e.g. Governance proposals listing may fetch all voting results
-   *   in order to filter the `ProposalCard`s and be able to provide the results.
+   * Render a custom status via render prop
    */
-  votingResult?: VotingResult;
+  renderStatus?: () => React.ReactNode;
 };
 
 const DEFAULT_BUTTON_TEXT: string = 'View Proposal';
@@ -43,20 +33,11 @@ const ResponsiveEllipsis = responsiveHOC()(LinesEllipsis);
 export default function ProposalCard(props: ProposalCardProps): JSX.Element {
   const {
     buttonText = DEFAULT_BUTTON_TEXT,
-    proposal,
     proposalOnClickId,
     onClick,
     name,
-    votingResult,
+    renderStatus,
   } = props;
-
-  /**
-   * Selectors
-   */
-
-  const votingAdapterName = useSelector(
-    (s: StoreState) => s.contracts.VotingContract?.adapterOrExtensionName
-  );
 
   /**
    * Functions
@@ -64,29 +45,6 @@ export default function ProposalCard(props: ProposalCardProps): JSX.Element {
 
   function handleClick() {
     onClick(proposalOnClickId);
-  }
-
-  /**
-   * Change status component based on voting adapter.
-   *
-   * @todo It's currently not possible to get the voting adapter used for a DAO proposal,
-   *   so until then we need to use the currently registered voting adapter for the DAO.
-   */
-  function renderStatus(proposal: ProposalData) {
-    switch (votingAdapterName) {
-      case VotingAdapterName.OffchainVotingContract:
-        return (
-          <OffchainVotingStatus
-            proposal={proposal}
-            votingResult={votingResult}
-          />
-        );
-      // @todo On-chain Voting
-      // case VotingAdapterName.VotingContract:
-      //   return <></>
-      default:
-        return <></>;
-    }
   }
 
   function renderName(name: string) {
@@ -114,8 +72,8 @@ export default function ProposalCard(props: ProposalCardProps): JSX.Element {
       {/* TITLE */}
       <h3 className="proposalcard__title">{renderName(name)}</h3>
 
-      {/* VOTING PROGRESS STATUS AND BAR */}
-      {renderStatus(proposal)}
+      {/* E.G. VOTING PROGRESS STATUS AND BAR */}
+      {renderStatus && renderStatus()}
 
       {/* BUTTON (no click handler) */}
       <button className="proposalcard__button">

--- a/src/components/proposals/ProposalCard.unit.test.tsx
+++ b/src/components/proposals/ProposalCard.unit.test.tsx
@@ -2,6 +2,7 @@ import {render, screen, waitFor} from '@testing-library/react';
 import {VoteChoices} from '@openlaw/snapshot-js-erc712';
 import userEvent from '@testing-library/user-event';
 
+import {OffchainVotingStatus} from './voting';
 import {ProposalData} from './types';
 import ProposalCard from './ProposalCard';
 import Wrapper from '../../test/Wrapper';
@@ -35,14 +36,16 @@ describe('ProposalCard unit tests', () => {
     fakeProposal.snapshotProposal?.msg.payload.name ||
     '';
 
-  test('should render a proposal card', async () => {
+  test('should render a proposal card with a status', async () => {
     render(
       <Wrapper useInit useWallet>
         <ProposalCard
           name={name}
-          proposal={fakeProposal as ProposalData}
           proposalOnClickId={fakeProposal.snapshotProposal?.idInDAO as string}
           onClick={() => {}}
+          renderStatus={() => (
+            <OffchainVotingStatus proposal={fakeProposal as ProposalData} />
+          )}
         />
       </Wrapper>
     );
@@ -54,6 +57,23 @@ describe('ProposalCard unit tests', () => {
     });
   });
 
+  test('should render a proposal card without a status', async () => {
+    render(
+      <Wrapper useInit useWallet>
+        <ProposalCard
+          name={name}
+          proposalOnClickId={fakeProposal.snapshotProposal?.idInDAO as string}
+          onClick={() => {}}
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/such a great proposal/i)).toBeInTheDocument();
+      expect(screen.getByText(/view proposal/i)).toBeInTheDocument();
+    });
+  });
+
   test('can click a proposal card', async () => {
     const spy = jest.fn();
 
@@ -61,9 +81,11 @@ describe('ProposalCard unit tests', () => {
       <Wrapper useInit useWallet>
         <ProposalCard
           name={name}
-          proposal={fakeProposal as ProposalData}
           proposalOnClickId={fakeProposal.snapshotProposal?.idInDAO as string}
           onClick={spy}
+          renderStatus={() => (
+            <OffchainVotingStatus proposal={fakeProposal as ProposalData} />
+          )}
         />
       </Wrapper>
     );
@@ -88,9 +110,11 @@ describe('ProposalCard unit tests', () => {
         <ProposalCard
           buttonText="Sponsor proposal"
           name={name}
-          proposal={fakeProposal as ProposalData}
           proposalOnClickId={fakeProposal.snapshotProposal?.idInDAO as string}
           onClick={spy}
+          renderStatus={() => (
+            <OffchainVotingStatus proposal={fakeProposal as ProposalData} />
+          )}
         />
       </Wrapper>
     );
@@ -112,9 +136,11 @@ describe('ProposalCard unit tests', () => {
           // Test when empty string
           buttonText=""
           name={name}
-          proposal={fakeProposal as ProposalData}
           proposalOnClickId={fakeProposal.snapshotProposal?.idInDAO as string}
           onClick={spy}
+          renderStatus={() => (
+            <OffchainVotingStatus proposal={fakeProposal as ProposalData} />
+          )}
         />
       </Wrapper>
     );

--- a/src/components/proposals/ProposalWithOffchainVoteActions.tsx
+++ b/src/components/proposals/ProposalWithOffchainVoteActions.tsx
@@ -79,7 +79,7 @@ export default function ProposalWithOffchainVoteActions(
         )}
 
         {/* OFF-CHAIN VOTING SUBMIT VOTE RESULT */}
-        {/* @todo A wrapping component to get the correct off-chain voting component */}
+        {/* @todo Perhaps use a wrapping component to get the correct off-chain voting component (e.g. op-rollup, batch) */}
         {status === ProposalFlowStatus.OffchainVotingSubmitResult && (
           <OffchainOpRollupVotingSubmitResultAction
             adapterName={adapterName}

--- a/src/components/proposals/ProposalWithOffchainVoteActions.tsx
+++ b/src/components/proposals/ProposalWithOffchainVoteActions.tsx
@@ -40,6 +40,7 @@ export default function ProposalWithOffchainVoteActions(
     daoProposalVotes && status === ProposalFlowStatus.OffchainVotingGracePeriod
       ? Number(daoProposalVotes.gracePeriodStartingTime) * 1000
       : 0;
+
   //  Currently, only Distribute adapter has an action that occurs after the
   //  proposal is processed.
   const showPostProcessAction =

--- a/src/components/proposals/ProposalWithOffchainVoteActions.tsx
+++ b/src/components/proposals/ProposalWithOffchainVoteActions.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import {
   OffchainVotingStatus,
   OffchainVotingAction,

--- a/src/components/proposals/helpers/getVotingAdapterABI.ts
+++ b/src/components/proposals/helpers/getVotingAdapterABI.ts
@@ -8,7 +8,7 @@ import {VotingAdapterName} from '../../adapters-extensions/enums';
  * Gets the ABI for a voting adapter by the adapter's adapter name.
  *
  * @param {VotingAdapterName} votingAdapterName
- * @returns {Promise<AbiItem>}
+ * @returns {Promise<AbiItem[]>}
  */
 export async function getVotingAdapterABI(
   votingAdapterName: VotingAdapterName

--- a/src/components/proposals/helpers/getVotingAdapterABI.ts
+++ b/src/components/proposals/helpers/getVotingAdapterABI.ts
@@ -1,0 +1,42 @@
+import {AbiItem} from 'web3-utils/types';
+
+import {VotingAdapterName} from '../../adapters-extensions/enums';
+
+/**
+ * getVotingAdapterABI
+ *
+ * Gets the ABI for a voting adapter by the adapter's adapter name.
+ *
+ * @param {VotingAdapterName} votingAdapterName
+ * @returns {Promise<AbiItem>}
+ */
+export async function getVotingAdapterABI(
+  votingAdapterName: VotingAdapterName
+): Promise<AbiItem[]> {
+  try {
+    switch (votingAdapterName) {
+      // Off-chain optimistic rollup
+      case VotingAdapterName.OffchainVotingContract:
+        const {default: lazyOffchainVotingABI} = await import(
+          '../../../truffle-contracts/OffchainVotingContract.json'
+        );
+
+        return lazyOffchainVotingABI as AbiItem[];
+
+      // On-chain voting
+      case VotingAdapterName.VotingContract:
+        const {default: lazyVotingABI} = await import(
+          '../../../truffle-contracts/VotingContract.json'
+        );
+
+        return lazyVotingABI as AbiItem[];
+
+      default:
+        throw new Error(
+          `No voting adapter name was found for "${votingAdapterName}".`
+        );
+    }
+  } catch (error) {
+    throw error;
+  }
+}

--- a/src/components/proposals/helpers/getVotingAdapterABI.unit.test.ts
+++ b/src/components/proposals/helpers/getVotingAdapterABI.unit.test.ts
@@ -1,0 +1,34 @@
+import {getVotingAdapterABI} from './';
+import {VotingAdapterName} from '../../adapters-extensions/enums';
+import OffchainVotingContractABI from '../../../truffle-contracts/OffchainVotingContract.json';
+import VotingContractABI from '../../../truffle-contracts/VotingContract.json';
+
+describe('getVotingAdapterABI unit tests', () => {
+  test('can return off-chain voting abi', async () => {
+    const abi = await getVotingAdapterABI(
+      VotingAdapterName.OffchainVotingContract
+    );
+
+    expect(abi).toMatchObject(OffchainVotingContractABI);
+  });
+
+  test('can return on-chain voting abi', async () => {
+    const abi = await getVotingAdapterABI(VotingAdapterName.VotingContract);
+
+    expect(abi).toMatchObject(VotingContractABI);
+  });
+
+  test('can throw error if bad voting adapter name', async () => {
+    let errorToTest: Error;
+
+    try {
+      await getVotingAdapterABI('ew' as VotingAdapterName);
+    } catch (error) {
+      errorToTest = error;
+    }
+
+    expect(errorToTest.message).toMatch(
+      /no voting adapter name was found for "ew"\./i
+    );
+  });
+});

--- a/src/components/proposals/helpers/index.ts
+++ b/src/components/proposals/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './getVoteChosen';
+export * from './getVotingAdapterABI';
 export * from './proposalHasFlag';
 export * from './proposalHasVotingState';

--- a/src/components/proposals/hooks/useOffchainVotingStartEnd.ts
+++ b/src/components/proposals/hooks/useOffchainVotingStartEnd.ts
@@ -39,9 +39,11 @@ export function useOffchainVotingStartEnd(
     hasOffchainVotingStarted,
     setHasOffchainVotingStarted,
   ] = useState<boolean>(false);
+
   const [hasOffchainVotingEnded, setHasOffchainVotingEnded] = useState<boolean>(
     false
   );
+
   const [
     offchainVotingStartEndInitReady,
     setOffchainVotingStartEndInitReady,

--- a/src/components/proposals/hooks/useProposalOrDraft.ts
+++ b/src/components/proposals/hooks/useProposalOrDraft.ts
@@ -280,6 +280,8 @@ export function useProposalOrDraft(
 
       return draft;
     } catch (error) {
+      if (!isMountedRef.current) return;
+
       setProposalStatus(AsyncStatus.REJECTED);
       setProposalError(error);
     }
@@ -345,6 +347,8 @@ export function useProposalOrDraft(
 
       return proposal;
     } catch (error) {
+      if (!isMountedRef.current) return;
+
       setProposalStatus(AsyncStatus.REJECTED);
       setProposalError(error);
     }

--- a/src/components/proposals/hooks/useProposalOrDraft.ts
+++ b/src/components/proposals/hooks/useProposalOrDraft.ts
@@ -1,12 +1,10 @@
-import {useCallback, useEffect, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import {
   SnapshotDraftResponse,
   SnapshotProposalResponse,
   SnapshotType,
 } from '@openlaw/snapshot-js-erc712';
 
-import {AsyncStatus} from '../../../util/types';
-import {SNAPSHOT_HUB_API_URL, SPACE} from '../../../config';
 import {
   Proposal,
   ProposalData,
@@ -15,7 +13,10 @@ import {
   SnapshotProposal,
   SnapshotProposalCommon,
 } from '../types';
+import {AsyncStatus} from '../../../util/types';
+import {SNAPSHOT_HUB_API_URL, SPACE} from '../../../config';
 import {useAbortController, useCounter} from '../../../hooks';
+import {useProposalsVotingAdapter} from './useProposalsVotingAdapter';
 
 type UseProposalReturn = {
   proposalData: ProposalData | undefined;
@@ -31,7 +32,7 @@ const ERROR_PROPOSAL_NOT_FOUND: string = 'Proposal was not found.';
 /**
  * useProposalOrDraft
  *
- * Ahook which fetches a snapshot-hub `proposal` or `draft` type by an ID string.
+ * Fetches a snapshot-hub `proposal` or `draft` type by an ID string.
  *
  * If no `type` argument is provided it will search first for a
  * `proposal`, then if not found, search for a `draft`.
@@ -46,6 +47,13 @@ export function useProposalOrDraft(
   id: string,
   type?: ProposalOrDraftSnapshotType
 ): UseProposalReturn {
+  /**
+   * Refs
+   */
+
+  // Prevents re-renders when passing the array to hooks
+  const idRef = useRef<typeof id[]>([id]);
+
   /**
    * State
    */
@@ -63,12 +71,32 @@ export function useProposalOrDraft(
     AsyncStatus.STANDBY
   );
 
+  // The overall status of the async data being fetched
+  const [
+    proposalInclusiveStatus,
+    setProposalInclusiveStatus,
+  ] = useState<AsyncStatus>(AsyncStatus.STANDBY);
+
+  // Any error of the async data being fetched
+  const [proposalInclusiveError, setProposalInclusiveError] = useState<Error>();
+
   /**
    * Our hooks
    */
 
   const {abortController, isMountedRef} = useAbortController();
+
   const [refetchCount, updateRefetchCount] = useCounter();
+
+  /**
+   * Fetch on-chain voting adapter data for proposals.
+   * Only returns data for proposals of which voting adapters have been assigned (i.e. sponsored).
+   */
+  const {
+    proposalsVotingAdapters,
+    proposalsVotingAdaptersError,
+    proposalsVotingAdaptersStatus,
+  } = useProposalsVotingAdapter(idRef.current);
 
   /**
    * Cached callbacks
@@ -80,6 +108,7 @@ export function useProposalOrDraft(
     isMountedRef,
     refetchCount,
   ]);
+
   const handleGetProposalCached = useCallback(handleGetProposal, [
     abortController?.signal,
     id,
@@ -87,6 +116,7 @@ export function useProposalOrDraft(
     refetchCount,
     type,
   ]);
+
   const handleGetProposalOrDraftCached = useCallback(handleGetProposalOrDraft, [
     handleGetDraftCached,
     handleGetProposalCached,
@@ -109,7 +139,9 @@ export function useProposalOrDraft(
   const proposalData: UseProposalReturn['proposalData'] =
     snapshotDraft || snapshotProposal
       ? {
+          // idInDAO: '',
           daoProposal,
+          daoProposalVotingAdapter: proposalsVotingAdapters[0]?.[1],
           getCommonSnapshotProposalData,
           refetchProposalOrDraft,
           snapshotDraft,
@@ -143,6 +175,68 @@ export function useProposalOrDraft(
     handleGetProposalOrDraftCached,
     type,
   ]);
+
+  // Set overall async status
+  useEffect(() => {
+    const {STANDBY, PENDING, FULFILLED, REJECTED} = AsyncStatus;
+    const statuses = [proposalStatus, proposalsVotingAdaptersStatus];
+
+    /**
+     * Standby
+     *
+     * The other statuses rely on a Snapshot Hub proposal or draft being fetched,
+     * so it's only in `STANDBY` at the point the proposals have
+     * not yet been fetched.
+     */
+    if (proposalStatus === STANDBY) {
+      setProposalInclusiveStatus(STANDBY);
+
+      return;
+    }
+
+    // Pending
+    if (statuses.some((s) => s === PENDING)) {
+      setProposalInclusiveStatus(PENDING);
+
+      return;
+    }
+
+    // Fulfilled
+    if (statuses.every((s) => s === FULFILLED)) {
+      setProposalInclusiveStatus(FULFILLED);
+
+      return;
+    }
+
+    // Fulfilled: checked for DAO proposals' voting adapters and none were returned - not sponsored
+    if (
+      proposalStatus === FULFILLED &&
+      proposalsVotingAdaptersStatus === FULFILLED &&
+      !proposalsVotingAdapters.length
+    ) {
+      setProposalInclusiveStatus(FULFILLED);
+
+      return;
+    }
+
+    // Rejected
+    if (statuses.some((s) => s === REJECTED)) {
+      setProposalInclusiveStatus(REJECTED);
+
+      return;
+    }
+  }, [
+    proposalStatus,
+    proposalsVotingAdapters.length,
+    proposalsVotingAdaptersStatus,
+  ]);
+
+  // Set any error from async calls
+  useEffect(() => {
+    const errors = [proposalError, proposalsVotingAdaptersError];
+
+    setProposalInclusiveError(errors.find((e) => e));
+  }, [proposalError, proposalsVotingAdaptersError]);
 
   /**
    * Functions
@@ -300,8 +394,8 @@ export function useProposalOrDraft(
 
   return {
     proposalData,
-    proposalError,
+    proposalError: proposalInclusiveError,
     proposalNotFound,
-    proposalStatus,
+    proposalStatus: proposalInclusiveStatus,
   };
 }

--- a/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.unit.test.ts
@@ -1,0 +1,1449 @@
+import {AbiItem} from 'web3-utils/types';
+import {act, renderHook} from '@testing-library/react-hooks';
+import {VoteChoices, SnapshotType} from '@openlaw/snapshot-js-erc712';
+import {waitFor} from '@testing-library/react';
+import Web3 from 'web3';
+
+import {
+  DEFAULT_ETH_ADDRESS,
+  DEFAULT_PROPOSAL_HASH,
+  FakeHttpProvider,
+} from '../../../test/helpers';
+import {
+  ProposalData,
+  ProposalFlowStatus,
+  SnapshotDraft,
+  SnapshotProposal,
+} from '../types';
+import {BURN_ADDRESS} from '../../../util/constants';
+import {proposalHasVotingState} from '../helpers';
+import {useProposalWithOffchainVoteStatus} from '.';
+import {VotingAdapterName} from '../../adapters-extensions/enums';
+import {VotingState} from '../voting/types';
+import OffchainVotingABI from '../../../truffle-contracts/OffchainVotingContract.json';
+import Wrapper from '../../../test/Wrapper';
+
+const nowSeconds = Date.now() / 1000;
+
+const fakeSnapshotProposal: SnapshotProposal = {
+  msg: {
+    payload: {
+      snapshot: 123,
+      name: '',
+      body: '',
+      choices: [VoteChoices.Yes, VoteChoices.No],
+      metadata: {},
+      start: nowSeconds - 5,
+      end: nowSeconds + 5,
+    },
+    version: '',
+    timestamp: '',
+    token: '',
+    type: SnapshotType.proposal,
+  },
+  actionId: '',
+  address: '',
+  authorIpfsHash: '',
+  data: {authorIpfsHash: ''},
+  idInDAO: DEFAULT_PROPOSAL_HASH,
+  idInSnapshot: DEFAULT_PROPOSAL_HASH,
+  relayerIpfsHash: '',
+  sig: '',
+  votes: [],
+};
+
+const fakeSnapshotDraft: SnapshotDraft = {
+  msg: {
+    payload: {
+      name: '',
+      body: '',
+      choices: [VoteChoices.Yes, VoteChoices.No],
+      metadata: {},
+    },
+    version: '',
+    timestamp: '',
+    token: '',
+    type: SnapshotType.draft,
+  },
+  actionId: '',
+  address: '',
+  authorIpfsHash: '',
+  data: {authorIpfsHash: '', sponsored: false},
+  idInDAO: DEFAULT_PROPOSAL_HASH,
+  idInSnapshot: DEFAULT_PROPOSAL_HASH,
+  relayerIpfsHash: '',
+  sig: '',
+};
+
+describe('useProposalWithOffchainVoteStatus unit tests', () => {
+  test('should return correct data from hook when status is `ProposalFlowStatus.Sponsor`', async () => {
+    const proposalData: Partial<ProposalData> = {
+      daoProposalVotingAdapter: undefined,
+      snapshotDraft: fakeSnapshotDraft,
+    };
+
+    let mockWeb3Provider: FakeHttpProvider;
+    let web3Instance: Web3;
+
+    await act(async () => {
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: (p) => {
+              mockWeb3Provider = p.mockWeb3Provider;
+              web3Instance = p.web3Instance;
+            },
+          },
+        }
+      );
+
+      await waitFor(() => {
+        mockWeb3Provider.injectResult(
+          web3Instance.eth.abi.encodeParameters(
+            ['uint256', 'bytes[]'],
+            [
+              0,
+              [
+                // For `proposals` call
+                web3Instance.eth.abi.encodeParameter(
+                  {
+                    Proposal: {
+                      adapterAddress: 'address',
+                      flags: 'uint256',
+                    },
+                  },
+                  {
+                    adapterAddress: DEFAULT_ETH_ADDRESS,
+                    // ProposalFlag.EXISTS
+                    flags: '1',
+                  }
+                ),
+              ],
+            ]
+          )
+        );
+      });
+
+      // Assert initial state
+      expect(result.current.daoProposal).toBe(undefined);
+      expect(result.current.daoProposalVoteResult).toBe(undefined);
+      expect(result.current.daoProposalVotes).toBe(undefined);
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.daoProposal);
+
+      expect(result.current.daoProposal).toMatchObject({
+        '0': '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        '1': '1',
+        __length__: 2,
+        adapterAddress: '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        flags: '1',
+      });
+
+      expect(result.current.daoProposalVoteResult).toBe(undefined);
+      expect(result.current.daoProposalVotes).toBe(undefined);
+      expect(result.current.status).toBe(ProposalFlowStatus.Sponsor);
+    });
+  });
+
+  test('should return correct data from hook when status is `ProposalFlowStatus.OffchainVoting`', async () => {
+    const proposalData: Partial<ProposalData> = {
+      daoProposalVotingAdapter: {
+        votingAdapterAddress: DEFAULT_ETH_ADDRESS,
+        votingAdapterName: VotingAdapterName.OffchainVotingContract,
+        getVotingAdapterABI: () => OffchainVotingABI as AbiItem[],
+        getWeb3VotingAdapterContract: () => undefined as any,
+      },
+      snapshotProposal: fakeSnapshotProposal,
+    };
+
+    await act(async () => {
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      // For `proposals` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Proposal: {
+                            adapterAddress: 'address',
+                            flags: 'uint256',
+                          },
+                        },
+                        {
+                          adapterAddress: DEFAULT_ETH_ADDRESS,
+                          // ProposalFlag.SPONSORED
+                          flags: '3',
+                        }
+                      ),
+                      // For `votes` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Voting: {
+                            snapshot: 'uint256',
+                            proposalHash: 'bytes32',
+                            reporter: 'address',
+                            resultRoot: 'bytes32',
+                            nbYes: 'uint256',
+                            nbNo: 'uint256',
+                            index: 'uint256',
+                            startingTime: 'uint256',
+                            gracePeriodStartingTime: 'uint256',
+                            isChallenged: 'bool',
+                            fallbackVotesCount: 'uint256',
+                          },
+                        },
+                        {
+                          snapshot: '0',
+                          proposalHash:
+                            '0x0000000000000000000000000000000000000000000000000000000000000000',
+                          reporter: BURN_ADDRESS,
+                          resultRoot:
+                            '0x0000000000000000000000000000000000000000000000000000000000000000',
+                          nbYes: '0',
+                          nbNo: '0',
+                          index: '0',
+                          startingTime: '0',
+                          gracePeriodStartingTime: '0',
+                          isChallenged: false,
+                          fallbackVotesCount: '0',
+                        }
+                      ),
+                      // For `voteResult` call (VotingState.IN_PROGRESS)
+                      web3Instance.eth.abi.encodeParameter('uint8', '4'),
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      // Assert initial state
+      expect(result.current.daoProposal).toBe(undefined);
+      expect(result.current.daoProposalVoteResult).toBe(undefined);
+      expect(result.current.daoProposalVotes).toBe(undefined);
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.daoProposal);
+
+      expect(result.current.daoProposal).toMatchObject({
+        '0': '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        '1': '3',
+        __length__: 2,
+        adapterAddress: '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        flags: '3',
+      });
+
+      expect(
+        proposalHasVotingState(
+          VotingState.IN_PROGRESS,
+          result.current.daoProposalVoteResult || ''
+        )
+      ).toBe(true);
+
+      expect(result.current.daoProposalVotes).toMatchObject({
+        '0': '0',
+        '1':
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '10': '0',
+        '2': BURN_ADDRESS,
+        '3':
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '4': '0',
+        '5': '0',
+        '6': '0',
+        '7': '0',
+        '8': '0',
+        '9': false,
+        __length__: 11,
+        fallbackVotesCount: '0',
+        gracePeriodStartingTime: '0',
+        index: '0',
+        isChallenged: false,
+        nbNo: '0',
+        nbYes: '0',
+        proposalHash:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        reporter: BURN_ADDRESS,
+        resultRoot:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        snapshot: '0',
+        startingTime: '0',
+      });
+
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.status);
+
+      expect(result.current.status).toBe(ProposalFlowStatus.OffchainVoting);
+    });
+  });
+
+  test('should return correct data from hook when status is `ProposalFlowStatus.OffchainVotingSubmitResult`', async () => {
+    const proposalData: Partial<ProposalData> = {
+      daoProposalVotingAdapter: {
+        votingAdapterAddress: DEFAULT_ETH_ADDRESS,
+        votingAdapterName: VotingAdapterName.OffchainVotingContract,
+        getVotingAdapterABI: () => OffchainVotingABI as AbiItem[],
+        getWeb3VotingAdapterContract: () => undefined as any,
+      },
+      snapshotProposal: {
+        ...fakeSnapshotProposal,
+        msg: {
+          ...fakeSnapshotProposal.msg,
+          payload: {
+            ...fakeSnapshotProposal.msg.payload,
+            // Set Snapshot offchain voting time as ended
+            start: nowSeconds - 100,
+            end: nowSeconds - 50,
+          },
+        },
+      },
+    };
+
+    await act(async () => {
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      // For `proposals` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Proposal: {
+                            adapterAddress: 'address',
+                            flags: 'uint256',
+                          },
+                        },
+                        {
+                          adapterAddress: DEFAULT_ETH_ADDRESS,
+                          // ProposalFlag.SPONSORED
+                          flags: '3',
+                        }
+                      ),
+                      // For `votes` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Voting: {
+                            snapshot: 'uint256',
+                            proposalHash: 'bytes32',
+                            reporter: 'address',
+                            resultRoot: 'bytes32',
+                            nbYes: 'uint256',
+                            nbNo: 'uint256',
+                            index: 'uint256',
+                            startingTime: 'uint256',
+                            gracePeriodStartingTime: 'uint256',
+                            isChallenged: 'bool',
+                            fallbackVotesCount: 'uint256',
+                          },
+                        },
+                        {
+                          snapshot: '0',
+                          proposalHash:
+                            '0x0000000000000000000000000000000000000000000000000000000000000000',
+                          reporter: BURN_ADDRESS,
+                          resultRoot:
+                            '0x0000000000000000000000000000000000000000000000000000000000000000',
+                          nbYes: '0',
+                          nbNo: '0',
+                          index: '0',
+                          startingTime: '0',
+                          gracePeriodStartingTime: '0',
+                          isChallenged: false,
+                          fallbackVotesCount: '0',
+                        }
+                      ),
+                      // For `voteResult` call (VotingState.GRACE_PERIOD)
+                      web3Instance.eth.abi.encodeParameter('uint8', '5'),
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      // Assert initial state
+      expect(result.current.daoProposal).toBe(undefined);
+      expect(result.current.daoProposalVoteResult).toBe(undefined);
+      expect(result.current.daoProposalVotes).toBe(undefined);
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.daoProposal);
+
+      expect(result.current.daoProposal).toMatchObject({
+        '0': '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        '1': '3',
+        __length__: 2,
+        adapterAddress: '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        flags: '3',
+      });
+
+      expect(
+        proposalHasVotingState(
+          VotingState.GRACE_PERIOD,
+          result.current.daoProposalVoteResult || ''
+        )
+      ).toBe(true);
+
+      expect(result.current.daoProposalVotes).toMatchObject({
+        '0': '0',
+        '1':
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '10': '0',
+        '2': BURN_ADDRESS,
+        '3':
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        '4': '0',
+        '5': '0',
+        '6': '0',
+        '7': '0',
+        '8': '0',
+        '9': false,
+        __length__: 11,
+        fallbackVotesCount: '0',
+        gracePeriodStartingTime: '0',
+        index: '0',
+        isChallenged: false,
+        nbNo: '0',
+        nbYes: '0',
+        proposalHash:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        reporter: BURN_ADDRESS,
+        resultRoot:
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+        snapshot: '0',
+        startingTime: '0',
+      });
+
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.status);
+
+      expect(result.current.status).toBe(
+        ProposalFlowStatus.OffchainVotingSubmitResult
+      );
+    });
+  });
+
+  test('should return correct data from hook when status is `ProposalFlowStatus.OffchainVotingGracePeriod`', async () => {
+    const proposalData: Partial<ProposalData> = {
+      daoProposalVotingAdapter: {
+        votingAdapterAddress: DEFAULT_ETH_ADDRESS,
+        votingAdapterName: VotingAdapterName.OffchainVotingContract,
+        getVotingAdapterABI: () => OffchainVotingABI as AbiItem[],
+        getWeb3VotingAdapterContract: () => undefined as any,
+      },
+      snapshotProposal: {
+        ...fakeSnapshotProposal,
+        msg: {
+          ...fakeSnapshotProposal.msg,
+          payload: {
+            ...fakeSnapshotProposal.msg.payload,
+            // Set Snapshot offchain voting time as ended
+            start: nowSeconds - 100,
+            end: nowSeconds - 50,
+          },
+        },
+      },
+    };
+
+    await act(async () => {
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      // For `proposals` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Proposal: {
+                            adapterAddress: 'address',
+                            flags: 'uint256',
+                          },
+                        },
+                        {
+                          adapterAddress: DEFAULT_ETH_ADDRESS,
+                          // ProposalFlag.SPONSORED
+                          flags: '3',
+                        }
+                      ),
+                      // For `votes` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Voting: {
+                            snapshot: 'uint256',
+                            proposalHash: 'bytes32',
+                            reporter: 'address',
+                            resultRoot: 'bytes32',
+                            nbYes: 'uint256',
+                            nbNo: 'uint256',
+                            index: 'uint256',
+                            startingTime: 'uint256',
+                            gracePeriodStartingTime: 'uint256',
+                            isChallenged: 'bool',
+                            fallbackVotesCount: 'uint256',
+                          },
+                        },
+                        {
+                          fallbackVotesCount: '0',
+                          gracePeriodStartingTime: '1617964640',
+                          index: '0',
+                          isChallenged: false,
+                          nbNo: '0',
+                          nbYes: '1',
+                          proposalHash: DEFAULT_PROPOSAL_HASH,
+                          reporter:
+                            '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+                          resultRoot:
+                            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+                          snapshot: '8376297',
+                          startingTime: '1617878162',
+                        }
+                      ),
+                      // For `voteResult` call (VotingState.GRACE_PERIOD)
+                      web3Instance.eth.abi.encodeParameter('uint8', '5'),
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      // Assert initial state
+      expect(result.current.daoProposal).toBe(undefined);
+      expect(result.current.daoProposalVoteResult).toBe(undefined);
+      expect(result.current.daoProposalVotes).toBe(undefined);
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.daoProposal);
+
+      expect(result.current.daoProposal).toMatchObject({
+        '0': '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        '1': '3',
+        __length__: 2,
+        adapterAddress: '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        flags: '3',
+      });
+
+      expect(
+        proposalHasVotingState(
+          VotingState.GRACE_PERIOD,
+          result.current.daoProposalVoteResult || ''
+        )
+      ).toBe(true);
+
+      expect(result.current.daoProposalVotes).toMatchObject({
+        '0': '8376297',
+        '1': DEFAULT_PROPOSAL_HASH,
+        '10': '0',
+        '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+        '3':
+          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+        '4': '1',
+        '5': '0',
+        '6': '0',
+        '7': '1617878162',
+        '8': '1617964640',
+        '9': false,
+        __length__: 11,
+        fallbackVotesCount: '0',
+        gracePeriodStartingTime: '1617964640',
+        index: '0',
+        isChallenged: false,
+        nbNo: '0',
+        nbYes: '1',
+        proposalHash: DEFAULT_PROPOSAL_HASH,
+        reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+        resultRoot:
+          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+        snapshot: '8376297',
+        startingTime: '1617878162',
+      });
+
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.status);
+
+      expect(result.current.status).toBe(
+        ProposalFlowStatus.OffchainVotingGracePeriod
+      );
+    });
+  });
+
+  test('should return correct data from hook when status is `ProposalFlowStatus.Process`', async () => {
+    const proposalData: Partial<ProposalData> = {
+      daoProposalVotingAdapter: {
+        votingAdapterAddress: DEFAULT_ETH_ADDRESS,
+        votingAdapterName: VotingAdapterName.OffchainVotingContract,
+        getVotingAdapterABI: () => OffchainVotingABI as AbiItem[],
+        getWeb3VotingAdapterContract: () => undefined as any,
+      },
+      snapshotProposal: {
+        ...fakeSnapshotProposal,
+        msg: {
+          ...fakeSnapshotProposal.msg,
+          payload: {
+            ...fakeSnapshotProposal.msg.payload,
+            // Set Snapshot offchain voting time as ended
+            start: nowSeconds - 100,
+            end: nowSeconds - 50,
+          },
+        },
+      },
+    };
+
+    await act(async () => {
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      // For `proposals` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Proposal: {
+                            adapterAddress: 'address',
+                            flags: 'uint256',
+                          },
+                        },
+                        {
+                          adapterAddress: DEFAULT_ETH_ADDRESS,
+                          // ProposalFlag.SPONSORED
+                          flags: '3',
+                        }
+                      ),
+                      // For `votes` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Voting: {
+                            snapshot: 'uint256',
+                            proposalHash: 'bytes32',
+                            reporter: 'address',
+                            resultRoot: 'bytes32',
+                            nbYes: 'uint256',
+                            nbNo: 'uint256',
+                            index: 'uint256',
+                            startingTime: 'uint256',
+                            gracePeriodStartingTime: 'uint256',
+                            isChallenged: 'bool',
+                            fallbackVotesCount: 'uint256',
+                          },
+                        },
+                        {
+                          fallbackVotesCount: '0',
+                          gracePeriodStartingTime: '1617964640',
+                          index: '0',
+                          isChallenged: false,
+                          nbNo: '0',
+                          nbYes: '1',
+                          proposalHash: DEFAULT_PROPOSAL_HASH,
+                          reporter:
+                            '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+                          resultRoot:
+                            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+                          snapshot: '8376297',
+                          startingTime: '1617878162',
+                        }
+                      ),
+                      // For `voteResult` call (VotingState.PASS)
+                      web3Instance.eth.abi.encodeParameter('uint8', '2'),
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      // Assert initial state
+      expect(result.current.daoProposal).toBe(undefined);
+      expect(result.current.daoProposalVoteResult).toBe(undefined);
+      expect(result.current.daoProposalVotes).toBe(undefined);
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.daoProposal);
+
+      expect(result.current.daoProposal).toMatchObject({
+        '0': '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        '1': '3',
+        __length__: 2,
+        adapterAddress: '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        flags: '3',
+      });
+
+      expect(
+        proposalHasVotingState(
+          VotingState.PASS,
+          result.current.daoProposalVoteResult || ''
+        )
+      ).toBe(true);
+
+      expect(result.current.daoProposalVotes).toMatchObject({
+        '0': '8376297',
+        '1': DEFAULT_PROPOSAL_HASH,
+        '10': '0',
+        '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+        '3':
+          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+        '4': '1',
+        '5': '0',
+        '6': '0',
+        '7': '1617878162',
+        '8': '1617964640',
+        '9': false,
+        __length__: 11,
+        fallbackVotesCount: '0',
+        gracePeriodStartingTime: '1617964640',
+        index: '0',
+        isChallenged: false,
+        nbNo: '0',
+        nbYes: '1',
+        proposalHash: DEFAULT_PROPOSAL_HASH,
+        reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+        resultRoot:
+          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+        snapshot: '8376297',
+        startingTime: '1617878162',
+      });
+
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.status);
+
+      expect(result.current.status).toBe(ProposalFlowStatus.Process);
+    });
+  });
+
+  test('should return correct data from hook when status is `ProposalFlowStatus.Completed`', async () => {
+    const proposalData: Partial<ProposalData> = {
+      daoProposalVotingAdapter: {
+        votingAdapterAddress: DEFAULT_ETH_ADDRESS,
+        votingAdapterName: VotingAdapterName.OffchainVotingContract,
+        getVotingAdapterABI: () => OffchainVotingABI as AbiItem[],
+        getWeb3VotingAdapterContract: () => undefined as any,
+      },
+      snapshotProposal: {
+        ...fakeSnapshotProposal,
+        msg: {
+          ...fakeSnapshotProposal.msg,
+          payload: {
+            ...fakeSnapshotProposal.msg.payload,
+            // Set Snapshot offchain voting time as ended
+            start: nowSeconds - 100,
+            end: nowSeconds - 50,
+          },
+        },
+      },
+    };
+
+    await act(async () => {
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      // For `proposals` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Proposal: {
+                            adapterAddress: 'address',
+                            flags: 'uint256',
+                          },
+                        },
+                        {
+                          adapterAddress: DEFAULT_ETH_ADDRESS,
+                          // ProposalFlag.PROCESSED
+                          flags: '7',
+                        }
+                      ),
+                      // For `votes` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Voting: {
+                            snapshot: 'uint256',
+                            proposalHash: 'bytes32',
+                            reporter: 'address',
+                            resultRoot: 'bytes32',
+                            nbYes: 'uint256',
+                            nbNo: 'uint256',
+                            index: 'uint256',
+                            startingTime: 'uint256',
+                            gracePeriodStartingTime: 'uint256',
+                            isChallenged: 'bool',
+                            fallbackVotesCount: 'uint256',
+                          },
+                        },
+                        {
+                          fallbackVotesCount: '0',
+                          gracePeriodStartingTime: '1617964640',
+                          index: '0',
+                          isChallenged: false,
+                          nbNo: '0',
+                          nbYes: '1',
+                          proposalHash: DEFAULT_PROPOSAL_HASH,
+                          reporter:
+                            '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+                          resultRoot:
+                            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+                          snapshot: '8376297',
+                          startingTime: '1617878162',
+                        }
+                      ),
+                      // For `voteResult` call (VotingState.PASS)
+                      web3Instance.eth.abi.encodeParameter('uint8', '2'),
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      // Assert initial state
+      expect(result.current.daoProposal).toBe(undefined);
+      expect(result.current.daoProposalVoteResult).toBe(undefined);
+      expect(result.current.daoProposalVotes).toBe(undefined);
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.daoProposal);
+
+      expect(result.current.daoProposal).toMatchObject({
+        '0': '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        '1': '7',
+        __length__: 2,
+        adapterAddress: '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        flags: '7',
+      });
+
+      expect(
+        proposalHasVotingState(
+          VotingState.PASS,
+          result.current.daoProposalVoteResult || ''
+        )
+      ).toBe(true);
+
+      expect(result.current.daoProposalVotes).toMatchObject({
+        '0': '8376297',
+        '1': DEFAULT_PROPOSAL_HASH,
+        '10': '0',
+        '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+        '3':
+          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+        '4': '1',
+        '5': '0',
+        '6': '0',
+        '7': '1617878162',
+        '8': '1617964640',
+        '9': false,
+        __length__: 11,
+        fallbackVotesCount: '0',
+        gracePeriodStartingTime: '1617964640',
+        index: '0',
+        isChallenged: false,
+        nbNo: '0',
+        nbYes: '1',
+        proposalHash: DEFAULT_PROPOSAL_HASH,
+        reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+        resultRoot:
+          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+        snapshot: '8376297',
+        startingTime: '1617878162',
+      });
+
+      expect(result.current.status).toBe(ProposalFlowStatus.Completed);
+    });
+  });
+
+  // @note This test uses higher timeouts
+  test('should poll for data when proposal is not processed', async () => {
+    const proposalData: Partial<ProposalData> = {
+      daoProposalVotingAdapter: {
+        votingAdapterAddress: DEFAULT_ETH_ADDRESS,
+        votingAdapterName: VotingAdapterName.OffchainVotingContract,
+        getVotingAdapterABI: () => OffchainVotingABI as AbiItem[],
+        getWeb3VotingAdapterContract: () => undefined as any,
+      },
+      snapshotProposal: {
+        ...fakeSnapshotProposal,
+        msg: {
+          ...fakeSnapshotProposal.msg,
+          payload: {
+            ...fakeSnapshotProposal.msg.payload,
+            // Set Snapshot offchain voting time as ended
+            start: nowSeconds - 100,
+            end: nowSeconds - 50,
+          },
+        },
+      },
+    };
+
+    let mockWeb3Provider: FakeHttpProvider;
+    let web3Instance: Web3;
+
+    await act(async () => {
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: (p) => {
+              mockWeb3Provider = p.mockWeb3Provider;
+              web3Instance = p.web3Instance;
+
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      // For `proposals` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Proposal: {
+                            adapterAddress: 'address',
+                            flags: 'uint256',
+                          },
+                        },
+                        {
+                          adapterAddress: DEFAULT_ETH_ADDRESS,
+                          // ProposalFlag.SPONSORED
+                          flags: '3',
+                        }
+                      ),
+                      // For `votes` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Voting: {
+                            snapshot: 'uint256',
+                            proposalHash: 'bytes32',
+                            reporter: 'address',
+                            resultRoot: 'bytes32',
+                            nbYes: 'uint256',
+                            nbNo: 'uint256',
+                            index: 'uint256',
+                            startingTime: 'uint256',
+                            gracePeriodStartingTime: 'uint256',
+                            isChallenged: 'bool',
+                            fallbackVotesCount: 'uint256',
+                          },
+                        },
+                        {
+                          fallbackVotesCount: '0',
+                          gracePeriodStartingTime: '1617964640',
+                          index: '0',
+                          isChallenged: false,
+                          nbNo: '0',
+                          nbYes: '1',
+                          proposalHash: DEFAULT_PROPOSAL_HASH,
+                          reporter:
+                            '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+                          resultRoot:
+                            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+                          snapshot: '8376297',
+                          startingTime: '1617878162',
+                        }
+                      ),
+                      // For `voteResult` call (VotingState.GRACE_PERIOD)
+                      web3Instance.eth.abi.encodeParameter('uint8', '5'),
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      // Assert initial state
+      expect(result.current.daoProposal).toBe(undefined);
+      expect(result.current.daoProposalVoteResult).toBe(undefined);
+      expect(result.current.daoProposalVotes).toBe(undefined);
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.daoProposal);
+
+      expect(result.current.daoProposal).toMatchObject({
+        '0': '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        '1': '3',
+        __length__: 2,
+        adapterAddress: '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        flags: '3',
+      });
+
+      expect(
+        proposalHasVotingState(
+          VotingState.GRACE_PERIOD,
+          result.current.daoProposalVoteResult || ''
+        )
+      ).toBe(true);
+
+      expect(result.current.daoProposalVotes).toMatchObject({
+        '0': '8376297',
+        '1': DEFAULT_PROPOSAL_HASH,
+        '10': '0',
+        '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+        '3':
+          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+        '4': '1',
+        '5': '0',
+        '6': '0',
+        '7': '1617878162',
+        '8': '1617964640',
+        '9': false,
+        __length__: 11,
+        fallbackVotesCount: '0',
+        gracePeriodStartingTime: '1617964640',
+        index: '0',
+        isChallenged: false,
+        nbNo: '0',
+        nbYes: '1',
+        proposalHash: DEFAULT_PROPOSAL_HASH,
+        reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+        resultRoot:
+          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+        snapshot: '8376297',
+        startingTime: '1617878162',
+      });
+
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.status);
+
+      expect(result.current.status).toBe(
+        ProposalFlowStatus.OffchainVotingGracePeriod
+      );
+
+      // Update the mock Web3 result for after polling
+      await waitFor(() => {
+        mockWeb3Provider.injectResult(
+          web3Instance.eth.abi.encodeParameters(
+            ['uint256', 'bytes[]'],
+            [
+              0,
+              [
+                // For `proposals` call
+                web3Instance.eth.abi.encodeParameter(
+                  {
+                    Proposal: {
+                      adapterAddress: 'address',
+                      flags: 'uint256',
+                    },
+                  },
+                  {
+                    adapterAddress: DEFAULT_ETH_ADDRESS,
+                    // ProposalFlag.SPONSORED
+                    flags: '3',
+                  }
+                ),
+                // For `votes` call
+                web3Instance.eth.abi.encodeParameter(
+                  {
+                    Voting: {
+                      snapshot: 'uint256',
+                      proposalHash: 'bytes32',
+                      reporter: 'address',
+                      resultRoot: 'bytes32',
+                      nbYes: 'uint256',
+                      nbNo: 'uint256',
+                      index: 'uint256',
+                      startingTime: 'uint256',
+                      gracePeriodStartingTime: 'uint256',
+                      isChallenged: 'bool',
+                      fallbackVotesCount: 'uint256',
+                    },
+                  },
+                  {
+                    fallbackVotesCount: '0',
+                    gracePeriodStartingTime: '1617964640',
+                    index: '0',
+                    isChallenged: false,
+                    nbNo: '0',
+                    nbYes: '1',
+                    proposalHash: DEFAULT_PROPOSAL_HASH,
+                    reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+                    resultRoot:
+                      '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+                    snapshot: '8376297',
+                    startingTime: '1617878162',
+                  }
+                ),
+                // For `voteResult` call (VotingState.PASS)
+                web3Instance.eth.abi.encodeParameter('uint8', '2'),
+              ],
+            ]
+          )
+        );
+      });
+
+      await waitForValueToChange(() => result.current.status, {timeout: 15000});
+
+      // After polling the `status` should change
+      await waitFor(() => {
+        expect(result.current.status).toBe(ProposalFlowStatus.Process);
+      });
+    });
+  }, 15000); // Set jest timeout for this test to a higher value to detect polling
+
+  test('should return error when async call throws on initial fetch', async () => {
+    const proposalData: Partial<ProposalData> = {
+      daoProposalVotingAdapter: undefined,
+      snapshotDraft: fakeSnapshotDraft,
+    };
+
+    await act(async () => {
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              mockWeb3Provider.injectError({
+                code: 1234,
+                message: 'Some bad error.',
+              });
+
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      // For `proposals` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Proposal: {
+                            adapterAddress: 'address',
+                            flags: 'uint256',
+                          },
+                        },
+                        {
+                          adapterAddress: DEFAULT_ETH_ADDRESS,
+                          // ProposalFlag.EXISTS
+                          flags: '1',
+                        }
+                      ),
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      // Assert initial state
+      expect(result.current.daoProposal).toBe(undefined);
+      expect(result.current.daoProposalVoteResult).toBe(undefined);
+      expect(result.current.daoProposalVotes).toBe(undefined);
+      expect(result.current.status).toBe(undefined);
+      expect(result.current.proposalFlowStatusError).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.proposalFlowStatusError);
+
+      expect(result.current.proposalFlowStatusError?.message).toMatch(
+        /some bad error\./i
+      );
+    });
+  });
+
+  // @note This test uses higher timeouts
+  test('should return error when async call throws during polling', async () => {
+    const proposalData: Partial<ProposalData> = {
+      daoProposalVotingAdapter: {
+        votingAdapterAddress: DEFAULT_ETH_ADDRESS,
+        votingAdapterName: VotingAdapterName.OffchainVotingContract,
+        getVotingAdapterABI: () => OffchainVotingABI as AbiItem[],
+        getWeb3VotingAdapterContract: () => undefined as any,
+      },
+      snapshotProposal: {
+        ...fakeSnapshotProposal,
+        msg: {
+          ...fakeSnapshotProposal.msg,
+          payload: {
+            ...fakeSnapshotProposal.msg.payload,
+            // Set Snapshot offchain voting time as ended
+            start: nowSeconds - 100,
+            end: nowSeconds - 50,
+          },
+        },
+      },
+    };
+
+    let mockWeb3Provider: FakeHttpProvider;
+    let web3Instance: Web3;
+
+    await act(async () => {
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: (p) => {
+              mockWeb3Provider = p.mockWeb3Provider;
+              web3Instance = p.web3Instance;
+
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      // For `proposals` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Proposal: {
+                            adapterAddress: 'address',
+                            flags: 'uint256',
+                          },
+                        },
+                        {
+                          adapterAddress: DEFAULT_ETH_ADDRESS,
+                          // ProposalFlag.SPONSORED
+                          flags: '3',
+                        }
+                      ),
+                      // For `votes` call
+                      web3Instance.eth.abi.encodeParameter(
+                        {
+                          Voting: {
+                            snapshot: 'uint256',
+                            proposalHash: 'bytes32',
+                            reporter: 'address',
+                            resultRoot: 'bytes32',
+                            nbYes: 'uint256',
+                            nbNo: 'uint256',
+                            index: 'uint256',
+                            startingTime: 'uint256',
+                            gracePeriodStartingTime: 'uint256',
+                            isChallenged: 'bool',
+                            fallbackVotesCount: 'uint256',
+                          },
+                        },
+                        {
+                          fallbackVotesCount: '0',
+                          gracePeriodStartingTime: '1617964640',
+                          index: '0',
+                          isChallenged: false,
+                          nbNo: '0',
+                          nbYes: '1',
+                          proposalHash: DEFAULT_PROPOSAL_HASH,
+                          reporter:
+                            '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+                          resultRoot:
+                            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+                          snapshot: '8376297',
+                          startingTime: '1617878162',
+                        }
+                      ),
+                      // For `voteResult` call (VotingState.GRACE_PERIOD)
+                      web3Instance.eth.abi.encodeParameter('uint8', '5'),
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      // Assert initial state
+      expect(result.current.daoProposal).toBe(undefined);
+      expect(result.current.daoProposalVoteResult).toBe(undefined);
+      expect(result.current.daoProposalVotes).toBe(undefined);
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.daoProposal);
+
+      expect(result.current.daoProposal).toMatchObject({
+        '0': '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        '1': '3',
+        __length__: 2,
+        adapterAddress: '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D',
+        flags: '3',
+      });
+
+      expect(
+        proposalHasVotingState(
+          VotingState.GRACE_PERIOD,
+          result.current.daoProposalVoteResult || ''
+        )
+      ).toBe(true);
+
+      expect(result.current.daoProposalVotes).toMatchObject({
+        '0': '8376297',
+        '1': DEFAULT_PROPOSAL_HASH,
+        '10': '0',
+        '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+        '3':
+          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+        '4': '1',
+        '5': '0',
+        '6': '0',
+        '7': '1617878162',
+        '8': '1617964640',
+        '9': false,
+        __length__: 11,
+        fallbackVotesCount: '0',
+        gracePeriodStartingTime: '1617964640',
+        index: '0',
+        isChallenged: false,
+        nbNo: '0',
+        nbYes: '1',
+        proposalHash: DEFAULT_PROPOSAL_HASH,
+        reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+        resultRoot:
+          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+        snapshot: '8376297',
+        startingTime: '1617878162',
+      });
+
+      expect(result.current.status).toBe(undefined);
+
+      await waitForValueToChange(() => result.current.status);
+
+      expect(result.current.status).toBe(
+        ProposalFlowStatus.OffchainVotingGracePeriod
+      );
+
+      // Update the mock Web3 result for after polling
+      await waitFor(() => {
+        mockWeb3Provider.injectResult(
+          web3Instance.eth.abi.encodeParameters(
+            ['uint256', 'bytes[]'],
+            [
+              0,
+              [
+                // For `proposals` call
+                web3Instance.eth.abi.encodeParameter(
+                  {
+                    Proposal: {
+                      adapterAddress: 'address',
+                      flags: 'uint256',
+                    },
+                  },
+                  {
+                    adapterAddress: DEFAULT_ETH_ADDRESS,
+                    // ProposalFlag.SPONSORED
+                    flags: '3',
+                  }
+                ),
+                // For `votes` call
+                web3Instance.eth.abi.encodeParameter(
+                  {
+                    Voting: {
+                      snapshot: 'uint256',
+                      proposalHash: 'bytes32',
+                      reporter: 'address',
+                      resultRoot: 'bytes32',
+                      nbYes: 'uint256',
+                      nbNo: 'uint256',
+                      index: 'uint256',
+                      startingTime: 'uint256',
+                      gracePeriodStartingTime: 'uint256',
+                      isChallenged: 'bool',
+                      fallbackVotesCount: 'uint256',
+                    },
+                  },
+                  {
+                    fallbackVotesCount: '0',
+                    gracePeriodStartingTime: '1617964640',
+                    index: '0',
+                    isChallenged: false,
+                    nbNo: '0',
+                    nbYes: '1',
+                    proposalHash: DEFAULT_PROPOSAL_HASH,
+                    reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+                    resultRoot:
+                      '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+                    snapshot: '8376297',
+                    startingTime: '1617878162',
+                  }
+                ),
+                // For `voteResult` call (VotingState.PASS)
+                web3Instance.eth.abi.encodeParameter('uint8', '2'),
+              ],
+            ]
+          )
+        );
+
+        mockWeb3Provider.injectError({
+          code: 1234,
+          message: 'Some bad error.',
+        });
+      });
+
+      await waitForValueToChange(() => result.current.proposalFlowStatusError, {
+        timeout: 15000,
+      });
+
+      expect(result.current.proposalFlowStatusError?.message).toMatch(
+        /some bad error\./i
+      );
+    });
+  }, 15000); // Set jest timeout for this test to a higher value to detect polling
+});

--- a/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.unit.test.ts
@@ -75,6 +75,126 @@ const fakeSnapshotDraft: SnapshotDraft = {
   sig: '',
 };
 
+const defaultVotesMock = [
+  {
+    Voting: {
+      snapshot: 'uint256',
+      proposalHash: 'bytes32',
+      reporter: 'address',
+      resultRoot: 'bytes32',
+      nbYes: 'uint256',
+      nbNo: 'uint256',
+      index: 'uint256',
+      startingTime: 'uint256',
+      gracePeriodStartingTime: 'uint256',
+      isChallenged: 'bool',
+      fallbackVotesCount: 'uint256',
+    },
+  },
+  {
+    fallbackVotesCount: '0',
+    gracePeriodStartingTime: '1617964640',
+    index: '0',
+    isChallenged: false,
+    nbNo: '0',
+    nbYes: '1',
+    proposalHash: DEFAULT_PROPOSAL_HASH,
+    reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+    resultRoot:
+      '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+    snapshot: '8376297',
+    startingTime: '1617878162',
+  },
+];
+
+const defaultVotesResult = {
+  '0': '8376297',
+  '1': DEFAULT_PROPOSAL_HASH,
+  '10': '0',
+  '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+  '3': '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+  '4': '1',
+  '5': '0',
+  '6': '0',
+  '7': '1617878162',
+  '8': '1617964640',
+  '9': false,
+  __length__: 11,
+  fallbackVotesCount: '0',
+  gracePeriodStartingTime: '1617964640',
+  index: '0',
+  isChallenged: false,
+  nbNo: '0',
+  nbYes: '1',
+  proposalHash: DEFAULT_PROPOSAL_HASH,
+  reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+  resultRoot:
+    '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+  snapshot: '8376297',
+  startingTime: '1617878162',
+};
+
+const defaultNoVotesMock = [
+  {
+    Voting: {
+      snapshot: 'uint256',
+      proposalHash: 'bytes32',
+      reporter: 'address',
+      resultRoot: 'bytes32',
+      nbYes: 'uint256',
+      nbNo: 'uint256',
+      index: 'uint256',
+      startingTime: 'uint256',
+      gracePeriodStartingTime: 'uint256',
+      isChallenged: 'bool',
+      fallbackVotesCount: 'uint256',
+    },
+  },
+  {
+    snapshot: '0',
+    proposalHash:
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+    reporter: BURN_ADDRESS,
+    resultRoot:
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+    nbYes: '0',
+    nbNo: '0',
+    index: '0',
+    startingTime: '0',
+    gracePeriodStartingTime: '0',
+    isChallenged: false,
+    fallbackVotesCount: '0',
+  },
+];
+
+const defaultNoVotesResult = {
+  '0': '0',
+  '1': '0x0000000000000000000000000000000000000000000000000000000000000000',
+  '10': '0',
+  '2': BURN_ADDRESS,
+  '3': '0x0000000000000000000000000000000000000000000000000000000000000000',
+  '4': '0',
+  '5': '0',
+  '6': '0',
+  '7': '0',
+  '8': '0',
+  '9': false,
+  __length__: 11,
+  fallbackVotesCount: '0',
+  gracePeriodStartingTime: '0',
+  index: '0',
+  isChallenged: false,
+  nbNo: '0',
+  nbYes: '0',
+  proposalHash:
+    '0x0000000000000000000000000000000000000000000000000000000000000000',
+  reporter: BURN_ADDRESS,
+  resultRoot:
+    '0x0000000000000000000000000000000000000000000000000000000000000000',
+  snapshot: '0',
+  startingTime: '0',
+};
+
 describe('useProposalWithOffchainVoteStatus unit tests', () => {
   test('should return correct data from hook when status is `ProposalFlowStatus.Sponsor`', async () => {
     const proposalData: Partial<ProposalData> = {
@@ -192,36 +312,8 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
                       ),
                       // For `votes` call
                       web3Instance.eth.abi.encodeParameter(
-                        {
-                          Voting: {
-                            snapshot: 'uint256',
-                            proposalHash: 'bytes32',
-                            reporter: 'address',
-                            resultRoot: 'bytes32',
-                            nbYes: 'uint256',
-                            nbNo: 'uint256',
-                            index: 'uint256',
-                            startingTime: 'uint256',
-                            gracePeriodStartingTime: 'uint256',
-                            isChallenged: 'bool',
-                            fallbackVotesCount: 'uint256',
-                          },
-                        },
-                        {
-                          snapshot: '0',
-                          proposalHash:
-                            '0x0000000000000000000000000000000000000000000000000000000000000000',
-                          reporter: BURN_ADDRESS,
-                          resultRoot:
-                            '0x0000000000000000000000000000000000000000000000000000000000000000',
-                          nbYes: '0',
-                          nbNo: '0',
-                          index: '0',
-                          startingTime: '0',
-                          gracePeriodStartingTime: '0',
-                          isChallenged: false,
-                          fallbackVotesCount: '0',
-                        }
+                        defaultNoVotesMock[0],
+                        defaultNoVotesMock[1]
                       ),
                       // For `voteResult` call (VotingState.IN_PROGRESS)
                       web3Instance.eth.abi.encodeParameter('uint8', '4'),
@@ -257,35 +349,9 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
         )
       ).toBe(true);
 
-      expect(result.current.daoProposalVotes).toMatchObject({
-        '0': '0',
-        '1':
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        '10': '0',
-        '2': BURN_ADDRESS,
-        '3':
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        '4': '0',
-        '5': '0',
-        '6': '0',
-        '7': '0',
-        '8': '0',
-        '9': false,
-        __length__: 11,
-        fallbackVotesCount: '0',
-        gracePeriodStartingTime: '0',
-        index: '0',
-        isChallenged: false,
-        nbNo: '0',
-        nbYes: '0',
-        proposalHash:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        reporter: BURN_ADDRESS,
-        resultRoot:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        snapshot: '0',
-        startingTime: '0',
-      });
+      expect(result.current.daoProposalVotes).toMatchObject(
+        defaultNoVotesResult
+      );
 
       expect(result.current.status).toBe(undefined);
 
@@ -348,36 +414,8 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
                       ),
                       // For `votes` call
                       web3Instance.eth.abi.encodeParameter(
-                        {
-                          Voting: {
-                            snapshot: 'uint256',
-                            proposalHash: 'bytes32',
-                            reporter: 'address',
-                            resultRoot: 'bytes32',
-                            nbYes: 'uint256',
-                            nbNo: 'uint256',
-                            index: 'uint256',
-                            startingTime: 'uint256',
-                            gracePeriodStartingTime: 'uint256',
-                            isChallenged: 'bool',
-                            fallbackVotesCount: 'uint256',
-                          },
-                        },
-                        {
-                          snapshot: '0',
-                          proposalHash:
-                            '0x0000000000000000000000000000000000000000000000000000000000000000',
-                          reporter: BURN_ADDRESS,
-                          resultRoot:
-                            '0x0000000000000000000000000000000000000000000000000000000000000000',
-                          nbYes: '0',
-                          nbNo: '0',
-                          index: '0',
-                          startingTime: '0',
-                          gracePeriodStartingTime: '0',
-                          isChallenged: false,
-                          fallbackVotesCount: '0',
-                        }
+                        defaultNoVotesMock[0],
+                        defaultNoVotesMock[1]
                       ),
                       // For `voteResult` call (VotingState.GRACE_PERIOD)
                       web3Instance.eth.abi.encodeParameter('uint8', '5'),
@@ -413,35 +451,9 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
         )
       ).toBe(true);
 
-      expect(result.current.daoProposalVotes).toMatchObject({
-        '0': '0',
-        '1':
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        '10': '0',
-        '2': BURN_ADDRESS,
-        '3':
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        '4': '0',
-        '5': '0',
-        '6': '0',
-        '7': '0',
-        '8': '0',
-        '9': false,
-        __length__: 11,
-        fallbackVotesCount: '0',
-        gracePeriodStartingTime: '0',
-        index: '0',
-        isChallenged: false,
-        nbNo: '0',
-        nbYes: '0',
-        proposalHash:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        reporter: BURN_ADDRESS,
-        resultRoot:
-          '0x0000000000000000000000000000000000000000000000000000000000000000',
-        snapshot: '0',
-        startingTime: '0',
-      });
+      expect(result.current.daoProposalVotes).toMatchObject(
+        defaultNoVotesResult
+      );
 
       expect(result.current.status).toBe(undefined);
 
@@ -506,36 +518,8 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
                       ),
                       // For `votes` call
                       web3Instance.eth.abi.encodeParameter(
-                        {
-                          Voting: {
-                            snapshot: 'uint256',
-                            proposalHash: 'bytes32',
-                            reporter: 'address',
-                            resultRoot: 'bytes32',
-                            nbYes: 'uint256',
-                            nbNo: 'uint256',
-                            index: 'uint256',
-                            startingTime: 'uint256',
-                            gracePeriodStartingTime: 'uint256',
-                            isChallenged: 'bool',
-                            fallbackVotesCount: 'uint256',
-                          },
-                        },
-                        {
-                          fallbackVotesCount: '0',
-                          gracePeriodStartingTime: '1617964640',
-                          index: '0',
-                          isChallenged: false,
-                          nbNo: '0',
-                          nbYes: '1',
-                          proposalHash: DEFAULT_PROPOSAL_HASH,
-                          reporter:
-                            '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-                          resultRoot:
-                            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-                          snapshot: '8376297',
-                          startingTime: '1617878162',
-                        }
+                        defaultVotesMock[0],
+                        defaultVotesMock[1]
                       ),
                       // For `voteResult` call (VotingState.GRACE_PERIOD)
                       web3Instance.eth.abi.encodeParameter('uint8', '5'),
@@ -571,33 +555,7 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
         )
       ).toBe(true);
 
-      expect(result.current.daoProposalVotes).toMatchObject({
-        '0': '8376297',
-        '1': DEFAULT_PROPOSAL_HASH,
-        '10': '0',
-        '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-        '3':
-          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-        '4': '1',
-        '5': '0',
-        '6': '0',
-        '7': '1617878162',
-        '8': '1617964640',
-        '9': false,
-        __length__: 11,
-        fallbackVotesCount: '0',
-        gracePeriodStartingTime: '1617964640',
-        index: '0',
-        isChallenged: false,
-        nbNo: '0',
-        nbYes: '1',
-        proposalHash: DEFAULT_PROPOSAL_HASH,
-        reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-        resultRoot:
-          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-        snapshot: '8376297',
-        startingTime: '1617878162',
-      });
+      expect(result.current.daoProposalVotes).toMatchObject(defaultVotesResult);
 
       expect(result.current.status).toBe(undefined);
 
@@ -662,36 +620,8 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
                       ),
                       // For `votes` call
                       web3Instance.eth.abi.encodeParameter(
-                        {
-                          Voting: {
-                            snapshot: 'uint256',
-                            proposalHash: 'bytes32',
-                            reporter: 'address',
-                            resultRoot: 'bytes32',
-                            nbYes: 'uint256',
-                            nbNo: 'uint256',
-                            index: 'uint256',
-                            startingTime: 'uint256',
-                            gracePeriodStartingTime: 'uint256',
-                            isChallenged: 'bool',
-                            fallbackVotesCount: 'uint256',
-                          },
-                        },
-                        {
-                          fallbackVotesCount: '0',
-                          gracePeriodStartingTime: '1617964640',
-                          index: '0',
-                          isChallenged: false,
-                          nbNo: '0',
-                          nbYes: '1',
-                          proposalHash: DEFAULT_PROPOSAL_HASH,
-                          reporter:
-                            '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-                          resultRoot:
-                            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-                          snapshot: '8376297',
-                          startingTime: '1617878162',
-                        }
+                        defaultVotesMock[0],
+                        defaultVotesMock[1]
                       ),
                       // For `voteResult` call (VotingState.PASS)
                       web3Instance.eth.abi.encodeParameter('uint8', '2'),
@@ -727,33 +657,7 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
         )
       ).toBe(true);
 
-      expect(result.current.daoProposalVotes).toMatchObject({
-        '0': '8376297',
-        '1': DEFAULT_PROPOSAL_HASH,
-        '10': '0',
-        '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-        '3':
-          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-        '4': '1',
-        '5': '0',
-        '6': '0',
-        '7': '1617878162',
-        '8': '1617964640',
-        '9': false,
-        __length__: 11,
-        fallbackVotesCount: '0',
-        gracePeriodStartingTime: '1617964640',
-        index: '0',
-        isChallenged: false,
-        nbNo: '0',
-        nbYes: '1',
-        proposalHash: DEFAULT_PROPOSAL_HASH,
-        reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-        resultRoot:
-          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-        snapshot: '8376297',
-        startingTime: '1617878162',
-      });
+      expect(result.current.daoProposalVotes).toMatchObject(defaultVotesResult);
 
       expect(result.current.status).toBe(undefined);
 
@@ -816,36 +720,8 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
                       ),
                       // For `votes` call
                       web3Instance.eth.abi.encodeParameter(
-                        {
-                          Voting: {
-                            snapshot: 'uint256',
-                            proposalHash: 'bytes32',
-                            reporter: 'address',
-                            resultRoot: 'bytes32',
-                            nbYes: 'uint256',
-                            nbNo: 'uint256',
-                            index: 'uint256',
-                            startingTime: 'uint256',
-                            gracePeriodStartingTime: 'uint256',
-                            isChallenged: 'bool',
-                            fallbackVotesCount: 'uint256',
-                          },
-                        },
-                        {
-                          fallbackVotesCount: '0',
-                          gracePeriodStartingTime: '1617964640',
-                          index: '0',
-                          isChallenged: false,
-                          nbNo: '0',
-                          nbYes: '1',
-                          proposalHash: DEFAULT_PROPOSAL_HASH,
-                          reporter:
-                            '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-                          resultRoot:
-                            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-                          snapshot: '8376297',
-                          startingTime: '1617878162',
-                        }
+                        defaultVotesMock[0],
+                        defaultVotesMock[1]
                       ),
                       // For `voteResult` call (VotingState.PASS)
                       web3Instance.eth.abi.encodeParameter('uint8', '2'),
@@ -881,33 +757,7 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
         )
       ).toBe(true);
 
-      expect(result.current.daoProposalVotes).toMatchObject({
-        '0': '8376297',
-        '1': DEFAULT_PROPOSAL_HASH,
-        '10': '0',
-        '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-        '3':
-          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-        '4': '1',
-        '5': '0',
-        '6': '0',
-        '7': '1617878162',
-        '8': '1617964640',
-        '9': false,
-        __length__: 11,
-        fallbackVotesCount: '0',
-        gracePeriodStartingTime: '1617964640',
-        index: '0',
-        isChallenged: false,
-        nbNo: '0',
-        nbYes: '1',
-        proposalHash: DEFAULT_PROPOSAL_HASH,
-        reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-        resultRoot:
-          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-        snapshot: '8376297',
-        startingTime: '1617878162',
-      });
+      expect(result.current.daoProposalVotes).toMatchObject(defaultVotesResult);
 
       expect(result.current.status).toBe(ProposalFlowStatus.Completed);
     });
@@ -973,36 +823,8 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
                       ),
                       // For `votes` call
                       web3Instance.eth.abi.encodeParameter(
-                        {
-                          Voting: {
-                            snapshot: 'uint256',
-                            proposalHash: 'bytes32',
-                            reporter: 'address',
-                            resultRoot: 'bytes32',
-                            nbYes: 'uint256',
-                            nbNo: 'uint256',
-                            index: 'uint256',
-                            startingTime: 'uint256',
-                            gracePeriodStartingTime: 'uint256',
-                            isChallenged: 'bool',
-                            fallbackVotesCount: 'uint256',
-                          },
-                        },
-                        {
-                          fallbackVotesCount: '0',
-                          gracePeriodStartingTime: '1617964640',
-                          index: '0',
-                          isChallenged: false,
-                          nbNo: '0',
-                          nbYes: '1',
-                          proposalHash: DEFAULT_PROPOSAL_HASH,
-                          reporter:
-                            '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-                          resultRoot:
-                            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-                          snapshot: '8376297',
-                          startingTime: '1617878162',
-                        }
+                        defaultVotesMock[0],
+                        defaultVotesMock[1]
                       ),
                       // For `voteResult` call (VotingState.GRACE_PERIOD)
                       web3Instance.eth.abi.encodeParameter('uint8', '5'),
@@ -1038,33 +860,7 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
         )
       ).toBe(true);
 
-      expect(result.current.daoProposalVotes).toMatchObject({
-        '0': '8376297',
-        '1': DEFAULT_PROPOSAL_HASH,
-        '10': '0',
-        '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-        '3':
-          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-        '4': '1',
-        '5': '0',
-        '6': '0',
-        '7': '1617878162',
-        '8': '1617964640',
-        '9': false,
-        __length__: 11,
-        fallbackVotesCount: '0',
-        gracePeriodStartingTime: '1617964640',
-        index: '0',
-        isChallenged: false,
-        nbNo: '0',
-        nbYes: '1',
-        proposalHash: DEFAULT_PROPOSAL_HASH,
-        reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-        resultRoot:
-          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-        snapshot: '8376297',
-        startingTime: '1617878162',
-      });
+      expect(result.current.daoProposalVotes).toMatchObject(defaultVotesResult);
 
       expect(result.current.status).toBe(undefined);
 
@@ -1098,35 +894,8 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
                 ),
                 // For `votes` call
                 web3Instance.eth.abi.encodeParameter(
-                  {
-                    Voting: {
-                      snapshot: 'uint256',
-                      proposalHash: 'bytes32',
-                      reporter: 'address',
-                      resultRoot: 'bytes32',
-                      nbYes: 'uint256',
-                      nbNo: 'uint256',
-                      index: 'uint256',
-                      startingTime: 'uint256',
-                      gracePeriodStartingTime: 'uint256',
-                      isChallenged: 'bool',
-                      fallbackVotesCount: 'uint256',
-                    },
-                  },
-                  {
-                    fallbackVotesCount: '0',
-                    gracePeriodStartingTime: '1617964640',
-                    index: '0',
-                    isChallenged: false,
-                    nbNo: '0',
-                    nbYes: '1',
-                    proposalHash: DEFAULT_PROPOSAL_HASH,
-                    reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-                    resultRoot:
-                      '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-                    snapshot: '8376297',
-                    startingTime: '1617878162',
-                  }
+                  defaultVotesMock[0],
+                  defaultVotesMock[1]
                 ),
                 // For `voteResult` call (VotingState.PASS)
                 web3Instance.eth.abi.encodeParameter('uint8', '2'),
@@ -1269,36 +1038,8 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
                       ),
                       // For `votes` call
                       web3Instance.eth.abi.encodeParameter(
-                        {
-                          Voting: {
-                            snapshot: 'uint256',
-                            proposalHash: 'bytes32',
-                            reporter: 'address',
-                            resultRoot: 'bytes32',
-                            nbYes: 'uint256',
-                            nbNo: 'uint256',
-                            index: 'uint256',
-                            startingTime: 'uint256',
-                            gracePeriodStartingTime: 'uint256',
-                            isChallenged: 'bool',
-                            fallbackVotesCount: 'uint256',
-                          },
-                        },
-                        {
-                          fallbackVotesCount: '0',
-                          gracePeriodStartingTime: '1617964640',
-                          index: '0',
-                          isChallenged: false,
-                          nbNo: '0',
-                          nbYes: '1',
-                          proposalHash: DEFAULT_PROPOSAL_HASH,
-                          reporter:
-                            '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-                          resultRoot:
-                            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-                          snapshot: '8376297',
-                          startingTime: '1617878162',
-                        }
+                        defaultVotesMock[0],
+                        defaultVotesMock[1]
                       ),
                       // For `voteResult` call (VotingState.GRACE_PERIOD)
                       web3Instance.eth.abi.encodeParameter('uint8', '5'),
@@ -1334,33 +1075,7 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
         )
       ).toBe(true);
 
-      expect(result.current.daoProposalVotes).toMatchObject({
-        '0': '8376297',
-        '1': DEFAULT_PROPOSAL_HASH,
-        '10': '0',
-        '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-        '3':
-          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-        '4': '1',
-        '5': '0',
-        '6': '0',
-        '7': '1617878162',
-        '8': '1617964640',
-        '9': false,
-        __length__: 11,
-        fallbackVotesCount: '0',
-        gracePeriodStartingTime: '1617964640',
-        index: '0',
-        isChallenged: false,
-        nbNo: '0',
-        nbYes: '1',
-        proposalHash: DEFAULT_PROPOSAL_HASH,
-        reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-        resultRoot:
-          '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-        snapshot: '8376297',
-        startingTime: '1617878162',
-      });
+      expect(result.current.daoProposalVotes).toMatchObject(defaultVotesResult);
 
       expect(result.current.status).toBe(undefined);
 
@@ -1394,35 +1109,8 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
                 ),
                 // For `votes` call
                 web3Instance.eth.abi.encodeParameter(
-                  {
-                    Voting: {
-                      snapshot: 'uint256',
-                      proposalHash: 'bytes32',
-                      reporter: 'address',
-                      resultRoot: 'bytes32',
-                      nbYes: 'uint256',
-                      nbNo: 'uint256',
-                      index: 'uint256',
-                      startingTime: 'uint256',
-                      gracePeriodStartingTime: 'uint256',
-                      isChallenged: 'bool',
-                      fallbackVotesCount: 'uint256',
-                    },
-                  },
-                  {
-                    fallbackVotesCount: '0',
-                    gracePeriodStartingTime: '1617964640',
-                    index: '0',
-                    isChallenged: false,
-                    nbNo: '0',
-                    nbYes: '1',
-                    proposalHash: DEFAULT_PROPOSAL_HASH,
-                    reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-                    resultRoot:
-                      '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-                    snapshot: '8376297',
-                    startingTime: '1617878162',
-                  }
+                  defaultVotesMock[0],
+                  defaultVotesMock[1]
                 ),
                 // For `voteResult` call (VotingState.PASS)
                 web3Instance.eth.abi.encodeParameter('uint8', '2'),

--- a/src/components/proposals/hooks/useProposals.ts
+++ b/src/components/proposals/hooks/useProposals.ts
@@ -82,7 +82,7 @@ export function useProposals({
    */
 
   /**
-   * Fetch voting adapter data for proposals.
+   * Fetch on-chain voting adapter data for proposals.
    * Only returns data for proposals of which voting adapters have been assigned (i.e. sponsored).
    */
   const {
@@ -91,14 +91,14 @@ export function useProposals({
     proposalsVotingAdaptersStatus,
   } = useProposalsVotingAdapter(daoProposalIds);
 
-  // Fetch voting state for proposals of which voting adapters have been assigned (i.e. sponsored)
+  // Fetch on-chain voting state for proposals of which voting adapters have been assigned (i.e. sponsored)
   const {
     proposalsVotingState,
     proposalsVotingStateError,
     proposalsVotingStateStatus,
   } = useProposalsVotingState(proposalsVotingAdapters);
 
-  // Fetch votes data for proposals of which voting adapters have been assigned (i.e. sponsored)
+  // Fetch on-chain votes data for proposals of which voting adapters have been assigned (i.e. sponsored)
   const {
     proposalsVotes,
     proposalsVotesError,

--- a/src/components/proposals/hooks/useProposals.ts
+++ b/src/components/proposals/hooks/useProposals.ts
@@ -81,18 +81,24 @@ export function useProposals({
    * Our hooks
    */
 
+  /**
+   * Fetch voting adapter data for proposals.
+   * Only returns data for proposals of which voting adapters have been assigned (i.e. sponsored).
+   */
   const {
     proposalsVotingAdapters,
     proposalsVotingAdaptersError,
     proposalsVotingAdaptersStatus,
   } = useProposalsVotingAdapter(daoProposalIds);
 
+  // Fetch voting state for proposals of which voting adapters have been assigned (i.e. sponsored)
   const {
     proposalsVotingState,
     proposalsVotingStateError,
     proposalsVotingStateStatus,
   } = useProposalsVotingState(proposalsVotingAdapters);
 
+  // Fetch votes data for proposals of which voting adapters have been assigned (i.e. sponsored)
   const {
     proposalsVotes,
     proposalsVotesError,
@@ -223,6 +229,25 @@ export function useProposals({
       return;
     }
 
+    // Fulfilled: checked for DAO proposals and none were returned
+    if (proposalsStatus === FULFILLED && !daoProposalIds.length) {
+      setProposalsInclusiveStatus(FULFILLED);
+
+      return;
+    }
+
+    // Fulfilled: checked for DAO proposals' voting adapters and none were returned - not sponsored
+    if (
+      proposalsStatus === FULFILLED &&
+      proposalsVotingAdaptersStatus === FULFILLED &&
+      daoProposalIds.length &&
+      !proposalsVotingAdapters.length
+    ) {
+      setProposalsInclusiveStatus(FULFILLED);
+
+      return;
+    }
+
     // Rejected
     if (statuses.some((s) => s === REJECTED)) {
       setProposalsInclusiveStatus(REJECTED);
@@ -230,8 +255,10 @@ export function useProposals({
       return;
     }
   }, [
+    daoProposalIds.length,
     proposalsStatus,
     proposalsVotesStatus,
+    proposalsVotingAdapters.length,
     proposalsVotingAdaptersStatus,
     proposalsVotingStateStatus,
   ]);

--- a/src/components/proposals/hooks/useProposals.ts
+++ b/src/components/proposals/hooks/useProposals.ts
@@ -429,6 +429,8 @@ export function useProposals({
               idInDAO,
               daoProposal: p,
               // To be set later in a `useEffect` above
+              daoProposalVotes: undefined,
+              // To be set later in a `useEffect` above
               daoProposalVotingAdapter: undefined,
               // To be set later in a `useEffect` above
               daoProposalVotingState: undefined,

--- a/src/components/proposals/hooks/useProposals.ts
+++ b/src/components/proposals/hooks/useProposals.ts
@@ -15,6 +15,7 @@ import {normalizeString} from '../../../util/helpers';
 import {Proposal, ProposalData} from '../types';
 import {SNAPSHOT_HUB_API_URL, SPACE} from '../../../config';
 import {StoreState} from '../../../store/types';
+import {useProposalsVotes} from './useProposalsVotes';
 import {useProposalsVotingAdapter} from './useProposalsVotingAdapter';
 import {useProposalsVotingState} from '.';
 import {useWeb3Modal} from '../../web3/hooks';
@@ -92,6 +93,12 @@ export function useProposals({
     proposalsVotingStateStatus,
   } = useProposalsVotingState(proposalsVotingAdapters);
 
+  const {
+    proposalsVotes,
+    proposalsVotesError,
+    proposalsVotesStatus,
+  } = useProposalsVotes(proposalsVotingAdapters);
+
   /**
    * Their hooks
    */
@@ -163,6 +170,22 @@ export function useProposals({
     );
   }, [proposalsVotingState]);
 
+  // Set `daoProposalVotes` data on the proposal
+  useEffect(() => {
+    if (!proposalsVotes.length) return;
+
+    setProposals((prevState) =>
+      prevState.map(
+        (p): ProposalData => ({
+          ...p,
+          daoProposalVotes: proposalsVotes.find(
+            ([id]) => normalizeString(id) === normalizeString(p.idInDAO || '')
+          )?.[1],
+        })
+      )
+    );
+  }, [proposalsVotes]);
+
   // Set overall async status
   useEffect(() => {
     const {STANDBY, PENDING, FULFILLED, REJECTED} = AsyncStatus;
@@ -170,6 +193,7 @@ export function useProposals({
       proposalsStatus,
       proposalsVotingAdaptersStatus,
       proposalsVotingStateStatus,
+      proposalsVotesStatus,
     ];
 
     /**
@@ -207,6 +231,7 @@ export function useProposals({
     }
   }, [
     proposalsStatus,
+    proposalsVotesStatus,
     proposalsVotingAdaptersStatus,
     proposalsVotingStateStatus,
   ]);
@@ -217,10 +242,16 @@ export function useProposals({
       proposalsError,
       proposalsVotingAdaptersError,
       proposalsVotingStateError,
+      proposalsVotesError,
     ];
 
     setProposalsInclusiveError(errors.find((e) => e));
-  }, [proposalsError, proposalsVotingAdaptersError, proposalsVotingStateError]);
+  }, [
+    proposalsError,
+    proposalsVotesError,
+    proposalsVotingAdaptersError,
+    proposalsVotingStateError,
+  ]);
 
   /**
    * Functions

--- a/src/components/proposals/hooks/useProposals.unit.test.ts
+++ b/src/components/proposals/hooks/useProposals.unit.test.ts
@@ -1,4 +1,5 @@
 import {renderHook, act} from '@testing-library/react-hooks';
+import {SnapshotType} from '@openlaw/snapshot-js-erc712';
 
 import {
   snapshotAPIDraftResponse,
@@ -8,16 +9,19 @@ import {
   DaoAdapterConstants,
   VotingAdapterName,
 } from '../../adapters-extensions/enums';
+import {
+  DEFAULT_DRAFT_HASH,
+  DEFAULT_ETH_ADDRESS,
+  DEFAULT_PROPOSAL_HASH,
+} from '../../../test/helpers';
 import {AsyncStatus} from '../../../util/types';
 import {BURN_ADDRESS} from '../../../util/constants';
-import {DEFAULT_DRAFT_HASH, DEFAULT_ETH_ADDRESS} from '../../../test/helpers';
+import {proposalHasVotingState} from '../helpers';
 import {rest, server} from '../../../test/server';
 import {SNAPSHOT_HUB_API_URL} from '../../../config';
 import {useProposals} from './useProposals';
-import Wrapper from '../../../test/Wrapper';
-import {SnapshotType} from '@openlaw/snapshot-js-erc712';
 import {VotingState} from '../voting/types';
-import {proposalHasVotingState} from '../helpers';
+import Wrapper from '../../../test/Wrapper';
 
 const mockWeb3Responses: Parameters<typeof Wrapper>[0]['getProps'] = ({
   mockWeb3Provider,
@@ -152,6 +156,72 @@ const mockWeb3Responses: Parameters<typeof Wrapper>[0]['getProps'] = ({
           web3Instance.eth.abi.encodeParameter('uint8', '4'),
         ],
       ]
+    )
+  );
+
+  /**
+   * Mock results for `useProposalsVotes`
+   *
+   * @note Maintain the same order as the contract's struct.
+   * @note We use the same, single result for any off-chain votes repsonses for testing only.
+   */
+  const offchainVotesDataResponse = web3Instance.eth.abi.encodeParameter(
+    {
+      Voting: {
+        snapshot: 'uint256',
+        proposalHash: 'bytes32',
+        reporter: 'address',
+        resultRoot: 'bytes32',
+        nbYes: 'uint256',
+        nbNo: 'uint256',
+        index: 'uint256',
+        startingTime: 'uint256',
+        gracePeriodStartingTime: 'uint256',
+        isChallenged: 'bool',
+        fallbackVotesCount: 'uint256',
+      },
+    },
+    {
+      snapshot: '8376297',
+      proposalHash: DEFAULT_PROPOSAL_HASH,
+      reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+      resultRoot:
+        '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+      nbYes: '1',
+      nbNo: '0',
+      index: '0',
+      startingTime: '1617878162',
+      gracePeriodStartingTime: '1617964640',
+      isChallenged: false,
+      fallbackVotesCount: '0',
+    }
+  );
+
+  /**
+   * @note Maintain the same order as the contract's struct.
+   */
+  const onchainVotesDataResponse = web3Instance.eth.abi.encodeParameter(
+    {
+      Voting: {
+        nbYes: 'uint256',
+        nbNo: 'uint256',
+        startingTime: 'uint256',
+        blockNumber: 'uint256',
+      },
+    },
+    {
+      blockNumber: '10',
+      nbNo: '50',
+      nbYes: '100',
+      startingTime: '1617878162',
+    }
+  );
+
+  // Mock votes data responses
+  mockWeb3Provider.injectResult(
+    web3Instance.eth.abi.encodeParameters(
+      ['uint256', 'bytes[]'],
+      [0, [offchainVotesDataResponse, onchainVotesDataResponse]]
     )
   );
 };
@@ -292,10 +362,6 @@ describe('useProposals unit tests', () => {
         result.current.proposals[1].daoProposalVotingAdapter?.votingAdapterName
       ).toBe(VotingAdapterName.OffchainVotingContract);
 
-      await waitForValueToChange(
-        () => result.current.proposals[1].daoProposalVotingState
-      );
-
       expect(
         proposalHasVotingState(
           VotingState.IN_PROGRESS,
@@ -309,6 +375,40 @@ describe('useProposals unit tests', () => {
           '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca69',
         idInSnapshot:
           '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca69',
+      });
+
+      await waitForValueToChange(
+        () => result.current.proposals[1].daoProposalVotes
+      );
+
+      expect(result.current.proposals[1].daoProposalVotes).toMatchObject({
+        OffchainVotingContract: {
+          '0': '8376297',
+          '1': DEFAULT_PROPOSAL_HASH,
+          '10': '0',
+          '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+          '3':
+            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+          '4': '1',
+          '5': '0',
+          '6': '0',
+          '7': '1617878162',
+          '8': '1617964640',
+          '9': false,
+          __length__: 11,
+          fallbackVotesCount: '0',
+          gracePeriodStartingTime: '1617964640',
+          index: '0',
+          isChallenged: false,
+          nbNo: '0',
+          nbYes: '1',
+          proposalHash: DEFAULT_PROPOSAL_HASH,
+          reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+          resultRoot:
+            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+          snapshot: '8376297',
+          startingTime: '1617878162',
+        },
       });
 
       // Assert Proposal 2
@@ -359,6 +459,20 @@ describe('useProposals unit tests', () => {
           '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca52',
         idInSnapshot:
           '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca52',
+      });
+
+      expect(result.current.proposals[2].daoProposalVotes).toMatchObject({
+        VotingContract: {
+          '0': '100',
+          '1': '50',
+          '2': '1617878162',
+          '3': '10',
+          __length__: 4,
+          blockNumber: '10',
+          nbNo: '50',
+          nbYes: '100',
+          startingTime: '1617878162',
+        },
       });
     });
   });

--- a/src/components/proposals/hooks/useProposals.unit.test.ts
+++ b/src/components/proposals/hooks/useProposals.unit.test.ts
@@ -345,6 +345,10 @@ describe('useProposals unit tests', () => {
         SnapshotType.proposal
       );
 
+      await waitForValueToChange(
+        () => result.current.proposals[1].daoProposalVotingAdapter
+      );
+
       expect(
         result.current.proposals[1].daoProposalVotingAdapter
           ?.getVotingAdapterABI
@@ -361,6 +365,10 @@ describe('useProposals unit tests', () => {
       expect(
         result.current.proposals[1].daoProposalVotingAdapter?.votingAdapterName
       ).toBe(VotingAdapterName.OffchainVotingContract);
+
+      await waitForValueToChange(
+        () => result.current.proposals[1].daoProposalVotingState
+      );
 
       expect(
         proposalHasVotingState(

--- a/src/components/proposals/hooks/useProposals.unit.test.ts
+++ b/src/components/proposals/hooks/useProposals.unit.test.ts
@@ -15,6 +15,7 @@ import {rest, server} from '../../../test/server';
 import {SNAPSHOT_HUB_API_URL} from '../../../config';
 import {useProposals} from './useProposals';
 import Wrapper from '../../../test/Wrapper';
+import {SnapshotType} from '@openlaw/snapshot-js-erc712';
 
 describe('useProposals unit tests', () => {
   test('should return correct hook state', async () => {
@@ -215,6 +216,10 @@ describe('useProposals unit tests', () => {
         flags: '1',
       });
 
+      expect(result.current.proposals[0].idInDAO).toBe(DEFAULT_DRAFT_HASH);
+
+      expect(result.current.proposals[0].snapshotType).toBe(SnapshotType.draft);
+
       expect(result.current.proposals[0].daoProposalVotingAdapter).toBe(
         undefined
       );
@@ -234,6 +239,14 @@ describe('useProposals unit tests', () => {
         adapterAddress: DEFAULT_ETH_ADDRESS,
         flags: '3',
       });
+
+      expect(result.current.proposals[1].idInDAO).toBe(
+        '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca69'
+      );
+
+      expect(result.current.proposals[1].snapshotType).toBe(
+        SnapshotType.proposal
+      );
 
       await waitForValueToChange(
         () => result.current.proposals[1].daoProposalVotingAdapter
@@ -273,6 +286,14 @@ describe('useProposals unit tests', () => {
         adapterAddress: DEFAULT_ETH_ADDRESS,
         flags: '3',
       });
+
+      expect(result.current.proposals[2].idInDAO).toBe(
+        '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca52'
+      );
+
+      expect(result.current.proposals[2].snapshotType).toBe(
+        SnapshotType.proposal
+      );
 
       expect(
         result.current.proposals[2].daoProposalVotingAdapter

--- a/src/components/proposals/hooks/useProposals.unit.test.ts
+++ b/src/components/proposals/hooks/useProposals.unit.test.ts
@@ -5,7 +5,10 @@ import {
   snapshotAPIProposalResponse,
 } from '../../../test/restResponses';
 import {AsyncStatus} from '../../../util/types';
-import {DaoAdapterConstants} from '../../adapters-extensions/enums';
+import {
+  DaoAdapterConstants,
+  VotingAdapterName,
+} from '../../adapters-extensions/enums';
 import {DEFAULT_ETH_ADDRESS} from '../../../test/helpers';
 import {rest, server} from '../../../test/server';
 import {SNAPSHOT_HUB_API_URL} from '../../../config';
@@ -28,7 +31,7 @@ describe('useProposals unit tests', () => {
         ]
       );
 
-      const {result, waitForNextUpdate} = await renderHook(
+      const {result, waitForValueToChange} = await renderHook(
         () => useProposals({adapterName: DaoAdapterConstants.ONBOARDING}),
         {
           wrapper: Wrapper,
@@ -73,6 +76,51 @@ describe('useProposals unit tests', () => {
                   ]
                 )
               );
+
+              /**
+               * Mock results for `useProposalsVotingAdapter`
+               */
+
+              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                DEFAULT_ETH_ADDRESS
+              );
+              const votingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                '0xa8ED02b24B4E9912e39337322885b65b23CdF188'
+              );
+
+              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.OffchainVotingContract
+              );
+
+              const votingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.VotingContract
+              );
+
+              // Mock `dao.votingAdapter` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotingAdapterResponse, votingAdapterResponse]]
+                )
+              );
+
+              // Mock `IVoting.getAdapterName` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      offchainVotingAdapterNameResponse,
+                      votingAdapterNameResponse,
+                    ],
+                  ]
+                )
+              );
             },
           },
         }
@@ -82,73 +130,13 @@ describe('useProposals unit tests', () => {
       expect(result.current.proposalsError).toBe(undefined);
       expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
 
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
-
-      await waitForNextUpdate();
+      await waitForValueToChange(() => result.current.proposalsStatus);
 
       expect(result.current.proposals).toMatchObject([]);
       expect(result.current.proposalsError).toBe(undefined);
       expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
 
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
-
-      await waitForNextUpdate();
+      await waitForValueToChange(() => result.current.proposalsStatus);
 
       expect(result.current.proposalsStatus).toBe(AsyncStatus.FULFILLED);
       expect(result.current.proposalsError).toBe(undefined);
@@ -195,7 +183,11 @@ describe('useProposals unit tests', () => {
         ]
       );
 
-      const {result, waitForNextUpdate} = await renderHook(
+      const {
+        result,
+        waitForNextUpdate,
+        waitForValueToChange,
+      } = await renderHook(
         () => useProposals({adapterName: DaoAdapterConstants.ONBOARDING}),
         {
           wrapper: Wrapper,
@@ -240,6 +232,51 @@ describe('useProposals unit tests', () => {
                   ]
                 )
               );
+
+              /**
+               * Mock results for `useProposalsVotingAdapter`
+               */
+
+              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                DEFAULT_ETH_ADDRESS
+              );
+              const votingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                '0xa8ED02b24B4E9912e39337322885b65b23CdF188'
+              );
+
+              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.OffchainVotingContract
+              );
+
+              const votingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.VotingContract
+              );
+
+              // Mock `dao.votingAdapter` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [0, [offchainVotingAdapterResponse, votingAdapterResponse]]
+                )
+              );
+
+              // Mock `IVoting.getAdapterName` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      offchainVotingAdapterNameResponse,
+                      votingAdapterNameResponse,
+                    ],
+                  ]
+                )
+              );
             },
           },
         }
@@ -249,75 +286,18 @@ describe('useProposals unit tests', () => {
       expect(result.current.proposalsError).toBe(undefined);
       expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
 
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
-
-      await waitForNextUpdate();
+      await waitForValueToChange(() => result.current.proposalsStatus);
 
       expect(result.current.proposals).toMatchObject([]);
       expect(result.current.proposalsError).toBe(undefined);
       expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
 
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposals).toMatchObject([]);
-      expect(result.current.proposalsError).toBe(undefined);
-      expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
-
-      await waitForNextUpdate();
+      await waitForValueToChange(() => result.current.proposalsStatus);
 
       expect(result.current.proposalsStatus).toBe(AsyncStatus.REJECTED);
+
+      await waitForValueToChange(() => result.current.proposalsError);
+
       expect(result.current.proposalsError?.message).toMatch(
         /something went wrong while fetching the/i
       );

--- a/src/components/proposals/hooks/useProposalsVotes.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.ts
@@ -4,6 +4,7 @@ import {AbiItem} from 'web3-utils/types';
 
 import {AsyncStatus} from '../../../util/types';
 import {BURN_ADDRESS} from '../../../util/constants';
+import {getVotingAdapterABI} from '../helpers';
 import {multicall, MulticallTuple} from '../../web3/helpers';
 import {OffchainVotingAdapterVotes, VotingAdapterVotes} from '../types';
 import {StoreState} from '../../../store/types';
@@ -229,13 +230,11 @@ export function useProposalsVotes(
     votingAdapterName: VotingAdapterName
   ): Promise<AbiItem> {
     try {
+      const votingAdapterABI = await getVotingAdapterABI(votingAdapterName);
+
       switch (votingAdapterName) {
         case VotingAdapterName.OffchainVotingContract:
-          const {default: lazyOffchainVotingABI} = await import(
-            '../../../truffle-contracts/OffchainVotingContract.json'
-          );
-
-          const offchainVotesDataABI = (lazyOffchainVotingABI as AbiItem[]).find(
+          const offchainVotesDataABI = votingAdapterABI.find(
             (ai) => ai.name === 'votes'
           );
 
@@ -248,11 +247,7 @@ export function useProposalsVotes(
           return offchainVotesDataABI;
 
         case VotingAdapterName.VotingContract:
-          const {default: lazyVotingABI} = await import(
-            '../../../truffle-contracts/VotingContract.json'
-          );
-
-          const votingVotesDataABI = (lazyVotingABI as AbiItem[]).find(
+          const votingVotesDataABI = votingAdapterABI.find(
             (ai) => ai.name === 'votes'
           );
 

--- a/src/components/proposals/hooks/useProposalsVotes.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.ts
@@ -2,11 +2,13 @@ import {useCallback, useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 import {AbiItem} from 'web3-utils/types';
 
+import {
+  OffchainVotingAdapterVotes,
+  ProposalVotingAdapterTuple,
+  VotingAdapterVotes,
+} from '../types';
 import {AsyncStatus} from '../../../util/types';
-import {BURN_ADDRESS} from '../../../util/constants';
-import {getVotingAdapterABI} from '../helpers';
 import {multicall, MulticallTuple} from '../../web3/helpers';
-import {OffchainVotingAdapterVotes, VotingAdapterVotes} from '../types';
 import {StoreState} from '../../../store/types';
 import {useWeb3Modal} from '../../web3/hooks';
 import {VotingAdapterName} from '../../adapters-extensions/enums';
@@ -29,7 +31,11 @@ type UseProposalsVotesReturn = {
 };
 
 export function useProposalsVotes(
-  proposalIds: string[]
+  /**
+   * A tuple of proposal id's and voting adapter data.
+   * This data is returned by `useProposalsVotingAdapter`.
+   */
+  proposalVotingAdapters: ProposalVotingAdapterTuple[]
 ): UseProposalsVotesReturn {
   /**
    * Selectors
@@ -65,7 +71,7 @@ export function useProposalsVotes(
    */
 
   const getProposalsVotesOnchainCached = useCallback(getProposalsVotesOnchain, [
-    proposalIds,
+    proposalVotingAdapters,
     registryABI,
     registryAddress,
     web3Instance,
@@ -84,14 +90,16 @@ export function useProposalsVotes(
    */
 
   async function getProposalsVotesOnchain() {
-    if (!registryAddress || !registryABI || !proposalIds.length) {
+    if (!registryAddress || !registryABI || !proposalVotingAdapters.length) {
       return;
     }
 
     // Only use hex (more specifically `bytes32`) id's
-    const safeProposalIds = proposalIds.filter(web3Instance.utils.isHexStrict);
+    const safeProposalVotingAdapters = proposalVotingAdapters.filter(([id]) =>
+      web3Instance.utils.isHexStrict(id)
+    );
 
-    if (!safeProposalIds.length) {
+    if (!safeProposalVotingAdapters.length) {
       setProposalsVotesStatus(AsyncStatus.FULFILLED);
       setProposalsVotes([]);
 
@@ -99,102 +107,23 @@ export function useProposalsVotes(
     }
 
     try {
-      const votingAdapterABI = registryABI.find(
-        (ai) => ai.name === 'votingAdapter'
-      );
-
-      if (!votingAdapterABI) {
-        throw new Error(
-          'No "votingAdapter" ABI function was found in the DAO registry ABI.'
-        );
-      }
-
-      // `DaoRegistry.votingAdapter` calls
-      const votingAdapterCalls: MulticallTuple[] = safeProposalIds.map((id) => [
-        registryAddress,
-        votingAdapterABI,
-        [id],
-      ]);
-
       setProposalsVotesStatus(AsyncStatus.PENDING);
-
-      const votingAdapterAddressResults: string[] = await multicall({
-        calls: votingAdapterCalls,
-        web3Instance,
-      });
-
-      const {default: lazyIVotingABI} = await import(
-        '../../../truffle-contracts/IVoting.json'
-      );
-
-      const getAdapterNameABI = (lazyIVotingABI as typeof registryABI).find(
-        (ai) => ai.name === 'getAdapterName'
-      );
-
-      if (!getAdapterNameABI) {
-        throw new Error(
-          'No "getAdapterName" ABI function was found in the IVoting ABI.'
-        );
-      }
-
-      /**
-       * Filter out `safeProposalIds` which are not sponsored (i.e. voting adapter address === `BURN_ADDRESS`).
-       * Filter out `votingAdapterAddressResults` which equal the `BURN_ADDRESS`.
-       *
-       * This ensures these two arrays maintain the same length as they rely on indexes for the
-       * proposals to match up to the array of `multicall` results.
-       */
-
-      const filteredProposalIds = safeProposalIds.filter(
-        (_id, i) => votingAdapterAddressResults[i] !== BURN_ADDRESS
-      );
-
-      const filteredVotingAdapterAddressResults = votingAdapterAddressResults.filter(
-        (a) => a !== BURN_ADDRESS
-      );
-
-      /**
-       * Exit early if there's no voting adapter addresses.
-       * It means no proposals were found to be sponsored
-       */
-      if (!filteredVotingAdapterAddressResults.length) {
-        setProposalsVotesStatus(AsyncStatus.FULFILLED);
-        setProposalsVotes([]);
-
-        return;
-      }
-
-      const votingAdapterNameCalls: MulticallTuple[] = filteredVotingAdapterAddressResults.map(
-        (votingAdapterAddress) => [votingAdapterAddress, getAdapterNameABI, []]
-      );
-
-      const adapterNameResults: VotingAdapterName[] = await multicall({
-        calls: votingAdapterNameCalls,
-        web3Instance,
-      });
-
-      let adapterNameMap: Record<string, VotingAdapterName>;
 
       // Build votes results
       const votesDataCalls: MulticallTuple[] = await Promise.all(
-        filteredProposalIds.map(
-          async (id, i): Promise<MulticallTuple> => {
-            // Set adapter name for setting the state later
-            adapterNameMap = {
-              ...adapterNameMap,
-              [id]: adapterNameResults[i],
-            };
-
-            return [
-              filteredVotingAdapterAddressResults[i],
-              await getVotesDataABI(adapterNameResults[i]),
-              /**
-               * We build the call arguments the same way for the different voting adapters
-               * (i.e. [dao, proposalId]). If we need to change this we can move it to another function.
-               */
-              [registryAddress, id],
-            ];
-          }
+        safeProposalVotingAdapters.map(
+          async ([
+            proposalId,
+            {votingAdapterAddress, getVotingAdapterABI, votingAdapterName},
+          ]): Promise<MulticallTuple> => [
+            votingAdapterAddress,
+            await getVotesDataABI(votingAdapterName, getVotingAdapterABI()),
+            /**
+             * We build the call arguments the same way for the different voting adapters
+             * (i.e. [dao, proposalId]). If we need to change this we can move it to another function.
+             */
+            [registryAddress, proposalId],
+          ]
         )
       );
 
@@ -205,12 +134,14 @@ export function useProposalsVotes(
 
       setProposalsVotesStatus(AsyncStatus.FULFILLED);
       setProposalsVotes(
-        safeProposalIds.map((id, i) => [
-          id,
-          {
-            [adapterNameMap[id]]: votesDataResults[i],
-          },
-        ])
+        safeProposalVotingAdapters.map(
+          ([proposalId, {votingAdapterName}], i) => [
+            proposalId,
+            {
+              [votingAdapterName]: votesDataResults[i],
+            },
+          ]
+        )
       );
     } catch (error) {
       setProposalsVotesStatus(AsyncStatus.REJECTED);
@@ -228,11 +159,10 @@ export function useProposalsVotes(
    * @returns {Promise<AbiItem>}
    */
   async function getVotesDataABI(
-    votingAdapterName: VotingAdapterName
+    votingAdapterName: VotingAdapterName,
+    votingAdapterABI: AbiItem[]
   ): Promise<AbiItem> {
     try {
-      const votingAdapterABI = await getVotingAdapterABI(votingAdapterName);
-
       switch (votingAdapterName) {
         case VotingAdapterName.OffchainVotingContract:
           const offchainVotesDataABI = votingAdapterABI.find(

--- a/src/components/proposals/hooks/useProposalsVotes.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.ts
@@ -2,30 +2,23 @@ import {useCallback, useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 import {AbiItem} from 'web3-utils/types';
 
-import {
-  OffchainVotingAdapterVotes,
-  ProposalVotingAdapterTuple,
-  VotingAdapterVotes,
-} from '../types';
 import {AsyncStatus} from '../../../util/types';
 import {multicall, MulticallTuple} from '../../web3/helpers';
+import {ProposalVotesData, ProposalVotingAdapterTuple} from '../types';
 import {StoreState} from '../../../store/types';
 import {useWeb3Modal} from '../../web3/hooks';
 import {VotingAdapterName} from '../../adapters-extensions/enums';
 
-type ProposalsVotesTuples = [
+type ProposalsVotesTuple = [
   proposalId: string,
   /**
    * For each proposal, each result is stored under its adapter name.
    */
-  adapterData: {
-    [VotingAdapterName.OffchainVotingContract]?: OffchainVotingAdapterVotes;
-    [VotingAdapterName.VotingContract]?: VotingAdapterVotes;
-  }
-][];
+  adapterData: ProposalVotesData
+];
 
 type UseProposalsVotesReturn = {
-  proposalsVotes: ProposalsVotesTuples;
+  proposalsVotes: ProposalsVotesTuple[];
   proposalsVotesError: Error | undefined;
   proposalsVotesStatus: AsyncStatus;
 };
@@ -58,7 +51,7 @@ export function useProposalsVotes(
    * State
    */
 
-  const [proposalsVotes, setProposalsVotes] = useState<ProposalsVotesTuples>(
+  const [proposalsVotes, setProposalsVotes] = useState<ProposalsVotesTuple[]>(
     []
   );
   const [proposalsVotesError, setProposalsVotesError] = useState<Error>();

--- a/src/components/proposals/hooks/useProposalsVotes.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.ts
@@ -93,6 +93,7 @@ export function useProposalsVotes(
 
     if (!safeProposalIds.length) {
       setProposalsVotesStatus(AsyncStatus.FULFILLED);
+      setProposalsVotes([]);
 
       return;
     }

--- a/src/components/proposals/hooks/useProposalsVotes.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.unit.test.ts
@@ -253,7 +253,7 @@ describe('useProposalsVotes unit tests', () => {
     });
   });
 
-  test('should return correct data on bad voting adapter name', async () => {
+  test('should return error on bad voting adapter name', async () => {
     const proposalIds = [DEFAULT_PROPOSAL_HASH];
 
     await act(async () => {

--- a/src/components/proposals/hooks/useProposalsVotes.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.unit.test.ts
@@ -1,50 +1,58 @@
 import {act, renderHook} from '@testing-library/react-hooks';
+import {AbiItem} from 'web3-utils/types';
 
 import {
   DEFAULT_ETH_ADDRESS,
   DEFAULT_PROPOSAL_HASH,
 } from '../../../test/helpers';
 import {AsyncStatus} from '../../../util/types';
+import {ProposalVotingAdapterData, ProposalVotingAdapterTuple} from '../types';
 import {useProposalsVotes} from './useProposalsVotes';
 import {VotingAdapterName} from '../../adapters-extensions/enums';
+import OffchainVotingABI from '../../../truffle-contracts/OffchainVotingContract.json';
+import VotingABI from '../../../truffle-contracts/VotingContract.json';
 import Wrapper from '../../../test/Wrapper';
 
 describe('useProposalsVotes unit tests', () => {
+  const defaultVotingAdapterData: ProposalVotingAdapterData = {
+    votingAdapterAddress: DEFAULT_ETH_ADDRESS,
+    votingAdapterName: VotingAdapterName.OffchainVotingContract,
+    getVotingAdapterABI: () => OffchainVotingABI as AbiItem[],
+    getWeb3VotingAdapterContract: () => undefined as any,
+  };
+
   test('should return correct data when OK', async () => {
-    const proposalIds = [
-      '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
-      '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca76',
-      '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca77',
+    const proposalsVotingAdapterTuples: ProposalVotingAdapterTuple[] = [
+      [DEFAULT_PROPOSAL_HASH, defaultVotingAdapterData],
+      // Set data other than the default to test multiple results
+      [
+        '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca76',
+        {
+          ...defaultVotingAdapterData,
+          votingAdapterAddress: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
+        },
+      ],
+      // Set data other than the default to test multiple results
+      [
+        '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca77',
+        {
+          ...defaultVotingAdapterData,
+          votingAdapterName: VotingAdapterName.VotingContract,
+          votingAdapterAddress: '0xa8ED02b24B4E9912e39337322885b65b23CdF188',
+          getVotingAdapterABI: () => VotingABI as AbiItem[],
+        },
+      ],
     ];
 
     await act(async () => {
       const {result, waitForNextUpdate} = await renderHook(
-        () => useProposalsVotes(proposalIds),
+        () => useProposalsVotes(proposalsVotingAdapterTuples),
         {
           wrapper: Wrapper,
           initialProps: {
             useInit: true,
             useWallet: true,
             getProps: ({mockWeb3Provider, web3Instance}) => {
-              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
-                'address',
-                DEFAULT_ETH_ADDRESS
-              );
-              const votingAdapterResponse = web3Instance.eth.abi.encodeParameter(
-                'address',
-                '0xa8ED02b24B4E9912e39337322885b65b23CdF188'
-              );
-
-              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
-                'string',
-                VotingAdapterName.OffchainVotingContract
-              );
-
-              const votingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
-                'string',
-                VotingAdapterName.VotingContract
-              );
-
               /**
                * @note Maintain the same order as the contract's struct.
                * @note We use the same, single result for any off-chain votes repsonses for testing only.
@@ -101,36 +109,6 @@ describe('useProposalsVotes unit tests', () => {
                 }
               );
 
-              // Mock `dao.votingAdapter` responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [
-                    0,
-                    [
-                      offchainVotingAdapterResponse,
-                      offchainVotingAdapterResponse,
-                      votingAdapterResponse,
-                    ],
-                  ]
-                )
-              );
-
-              // Mock `IVoting.getAdapterName` responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [
-                    0,
-                    [
-                      offchainVotingAdapterNameResponse,
-                      offchainVotingAdapterNameResponse,
-                      votingAdapterNameResponse,
-                    ],
-                  ]
-                )
-              );
-
               // Mock votes data responses
               mockWeb3Provider.injectResult(
                 web3Instance.eth.abi.encodeParameters(
@@ -166,12 +144,11 @@ describe('useProposalsVotes unit tests', () => {
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([
         [
-          '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+          DEFAULT_PROPOSAL_HASH,
           {
             OffchainVotingContract: {
               '0': '8376297',
-              '1':
-                '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+              '1': DEFAULT_PROPOSAL_HASH,
               '10': '0',
               '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
               '3':
@@ -189,8 +166,7 @@ describe('useProposalsVotes unit tests', () => {
               isChallenged: false,
               nbNo: '0',
               nbYes: '1',
-              proposalHash:
-                '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+              proposalHash: DEFAULT_PROPOSAL_HASH,
               reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
               resultRoot:
                 '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
@@ -204,8 +180,7 @@ describe('useProposalsVotes unit tests', () => {
           {
             OffchainVotingContract: {
               '0': '8376297',
-              '1':
-                '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+              '1': DEFAULT_PROPOSAL_HASH,
               '10': '0',
               '2': '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
               '3':
@@ -223,8 +198,7 @@ describe('useProposalsVotes unit tests', () => {
               isChallenged: false,
               nbNo: '0',
               nbYes: '1',
-              proposalHash:
-                '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+              proposalHash: DEFAULT_PROPOSAL_HASH,
               reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
               resultRoot:
                 '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
@@ -254,28 +228,26 @@ describe('useProposalsVotes unit tests', () => {
   });
 
   test('should return error on bad voting adapter name', async () => {
-    const proposalIds = [DEFAULT_PROPOSAL_HASH];
+    const proposalsVotingAdapterTuples: ProposalVotingAdapterTuple[] = [
+      [
+        '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca76',
+        {
+          ...defaultVotingAdapterData,
+          votingAdapterName: 'BadVotingAdapterName' as VotingAdapterName,
+          votingAdapterAddress: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
+        },
+      ],
+    ];
 
     await act(async () => {
-      const {result, waitForNextUpdate} = await renderHook(
-        () => useProposalsVotes(proposalIds),
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalsVotes(proposalsVotingAdapterTuples),
         {
           wrapper: Wrapper,
           initialProps: {
             useInit: true,
             useWallet: true,
             getProps: ({mockWeb3Provider, web3Instance}) => {
-              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
-                'address',
-                DEFAULT_ETH_ADDRESS
-              );
-
-              // @note Setting a bad voting adapter name to cause an error
-              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
-                'string',
-                'BadVotingAdapterName'
-              );
-
               /**
                * @note Maintain the same order as the contract's struct.
                * @note We use the same, single result for any off-chain votes repsonses for testing only.
@@ -312,22 +284,6 @@ describe('useProposalsVotes unit tests', () => {
                 }
               );
 
-              // Mock `dao.votingAdapter` responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [0, [offchainVotingAdapterResponse]]
-                )
-              );
-
-              // Mock `IVoting.getAdapterName` responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [0, [offchainVotingAdapterNameResponse]]
-                )
-              );
-
               // Mock votes data responses
               mockWeb3Provider.injectResult(
                 web3Instance.eth.abi.encodeParameters(
@@ -344,13 +300,7 @@ describe('useProposalsVotes unit tests', () => {
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);
 
-      await waitForNextUpdate();
-
-      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.PENDING);
-      expect(result.current.proposalsVotesError).toBe(undefined);
-      expect(result.current.proposalsVotes).toMatchObject([]);
-
-      await waitForNextUpdate();
+      await waitForValueToChange(() => result.current.proposalsVotesStatus);
 
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.REJECTED);
       expect(result.current.proposalsVotesError?.message).toMatch(
@@ -361,28 +311,27 @@ describe('useProposalsVotes unit tests', () => {
   });
 
   test('should only return data for hex proposal ids', async () => {
-    const proposalIds = ['badId', DEFAULT_PROPOSAL_HASH];
+    const proposalsVotingAdapterTuples: ProposalVotingAdapterTuple[] = [
+      ['badId-abc123', defaultVotingAdapterData],
+      // Set data other than the default to test multiple results
+      [
+        DEFAULT_PROPOSAL_HASH,
+        {
+          ...defaultVotingAdapterData,
+          votingAdapterAddress: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
+        },
+      ],
+    ];
 
     await act(async () => {
-      const {result, waitForNextUpdate} = await renderHook(
-        () => useProposalsVotes(proposalIds),
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalsVotes(proposalsVotingAdapterTuples),
         {
           wrapper: Wrapper,
           initialProps: {
             useInit: true,
             useWallet: true,
             getProps: ({mockWeb3Provider, web3Instance}) => {
-              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
-                'address',
-                DEFAULT_ETH_ADDRESS
-              );
-
-              // @note Setting a bad voting adapter name to cause an error
-              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
-                'string',
-                VotingAdapterName.OffchainVotingContract
-              );
-
               /**
                * @note Maintain the same order as the contract's struct.
                */
@@ -418,22 +367,6 @@ describe('useProposalsVotes unit tests', () => {
                 }
               );
 
-              // Mock `dao.votingAdapter` responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [0, [offchainVotingAdapterResponse]]
-                )
-              );
-
-              // Mock `IVoting.getAdapterName` responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [0, [offchainVotingAdapterNameResponse]]
-                )
-              );
-
               // Mock votes data responses
               mockWeb3Provider.injectResult(
                 web3Instance.eth.abi.encodeParameters(
@@ -450,13 +383,13 @@ describe('useProposalsVotes unit tests', () => {
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);
 
-      await waitForNextUpdate();
+      await waitForValueToChange(() => result.current.proposalsVotesStatus);
 
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.PENDING);
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);
 
-      await waitForNextUpdate();
+      await waitForValueToChange(() => result.current.proposalsVotesStatus);
 
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.FULFILLED);
       expect(result.current.proposalsVotesError?.message).toBe(undefined);
@@ -500,29 +433,27 @@ describe('useProposalsVotes unit tests', () => {
   });
 
   test('should return correct data when no bytes32[] proposal ids', async () => {
-    // Internal filtering will cause the resulting array to be empty.
-    const proposalIds = ['bad', 'erg', 'meow'];
+    // Internal filtering should cause the resulting array to be empty.
+    const proposalsVotingAdapterTuples: ProposalVotingAdapterTuple[] = [
+      ['bad', defaultVotingAdapterData],
+      [
+        'bad-one',
+        {
+          ...defaultVotingAdapterData,
+          votingAdapterAddress: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
+        },
+      ],
+    ];
 
     await act(async () => {
-      const {result, waitForNextUpdate} = await renderHook(
-        () => useProposalsVotes(proposalIds),
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalsVotes(proposalsVotingAdapterTuples),
         {
           wrapper: Wrapper,
           initialProps: {
             useInit: true,
             useWallet: true,
             getProps: ({mockWeb3Provider, web3Instance}) => {
-              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
-                'address',
-                DEFAULT_ETH_ADDRESS
-              );
-
-              // @note Setting a bad voting adapter name to cause an error
-              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
-                'string',
-                VotingAdapterName.OffchainVotingContract
-              );
-
               /**
                * @note Maintain the same order as the contract's struct.
                */
@@ -558,22 +489,6 @@ describe('useProposalsVotes unit tests', () => {
                 }
               );
 
-              // Mock `dao.votingAdapter` responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [0, [offchainVotingAdapterResponse]]
-                )
-              );
-
-              // Mock `IVoting.getAdapterName` responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [0, [offchainVotingAdapterNameResponse]]
-                )
-              );
-
               // Mock votes data responses
               mockWeb3Provider.injectResult(
                 web3Instance.eth.abi.encodeParameters(
@@ -590,7 +505,7 @@ describe('useProposalsVotes unit tests', () => {
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);
 
-      await waitForNextUpdate();
+      await waitForValueToChange(() => result.current.proposalsVotesStatus);
 
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.FULFILLED);
       expect(result.current.proposalsVotesError).toBe(undefined);
@@ -598,30 +513,19 @@ describe('useProposalsVotes unit tests', () => {
     });
   });
 
-  test('should return correct data when no proposal ids', async () => {
+  test('should not start when no proposal ids', async () => {
     // Internal filtering will cause the resulting array to be empty.
-    const proposalIds = [''];
+    const proposalsVotingAdapterTuples: ProposalVotingAdapterTuple[] = [];
 
     await act(async () => {
       const {result, waitForNextUpdate} = await renderHook(
-        () => useProposalsVotes(proposalIds),
+        () => useProposalsVotes(proposalsVotingAdapterTuples),
         {
           wrapper: Wrapper,
           initialProps: {
             useInit: true,
             useWallet: true,
             getProps: ({mockWeb3Provider, web3Instance}) => {
-              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
-                'address',
-                DEFAULT_ETH_ADDRESS
-              );
-
-              // @note Setting a bad voting adapter name to cause an error
-              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
-                'string',
-                VotingAdapterName.OffchainVotingContract
-              );
-
               /**
                * @note Maintain the same order as the contract's struct.
                */
@@ -657,22 +561,6 @@ describe('useProposalsVotes unit tests', () => {
                 }
               );
 
-              // Mock `dao.votingAdapter` responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [0, [offchainVotingAdapterResponse]]
-                )
-              );
-
-              // Mock `IVoting.getAdapterName` responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [0, [offchainVotingAdapterNameResponse]]
-                )
-              );
-
               // Mock votes data responses
               mockWeb3Provider.injectResult(
                 web3Instance.eth.abi.encodeParameters(
@@ -691,7 +579,7 @@ describe('useProposalsVotes unit tests', () => {
 
       await waitForNextUpdate();
 
-      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.FULFILLED);
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.STANDBY);
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);
     });

--- a/src/components/proposals/hooks/useProposalsVotingAdapter.ts
+++ b/src/components/proposals/hooks/useProposalsVotingAdapter.ts
@@ -2,7 +2,13 @@ import {AbiItem} from 'web3-utils/types';
 import {Contract} from 'web3-eth-contract/types';
 
 import {AsyncStatus} from '../../../util/types';
-import {useState} from 'react';
+import {BURN_ADDRESS} from '../../../util/constants';
+import {getVotingAdapterABI} from '../helpers';
+import {multicall, MulticallTuple} from '../../web3/helpers';
+import {StoreState} from '../../../store/types';
+import {useCallback, useEffect, useState} from 'react';
+import {useSelector} from 'react-redux';
+import {useWeb3Modal} from '../../web3/hooks';
 import {VotingAdapterName} from '../../adapters-extensions/enums';
 
 type VotingAdapterData = {
@@ -28,6 +34,23 @@ export function useProposalsVotingAdapter(
   proposalIds: string[]
 ): UseProposalsVotingAdapterReturn {
   /**
+   * Selectors
+   */
+
+  const registryAddress = useSelector(
+    (s: StoreState) => s.contracts.DaoRegistryContract?.contractAddress
+  );
+  const registryABI = useSelector(
+    (s: StoreState) => s.contracts.DaoRegistryContract?.abi
+  );
+
+  /**
+   * Our hooks
+   */
+
+  const {web3Instance} = useWeb3Modal();
+
+  /**
    * State
    */
 
@@ -48,6 +71,153 @@ export function useProposalsVotingAdapter(
   ] = useState<
     UseProposalsVotingAdapterReturn['proposalsVotingAdaptersStatus']
   >(AsyncStatus.STANDBY);
+
+  /**
+   * Cached callbacks
+   */
+
+  const getProposalsVotingAdaptersOnchainCached = useCallback(
+    getProposalsVotingAdaptersOnchain,
+    [proposalIds, registryABI, registryAddress, web3Instance]
+  );
+
+  /**
+   * Effects
+   */
+
+  useEffect(() => {
+    getProposalsVotingAdaptersOnchainCached();
+  }, [getProposalsVotingAdaptersOnchainCached]);
+
+  /**
+   * Functions
+   */
+
+  async function getProposalsVotingAdaptersOnchain(): Promise<void> {
+    if (!registryAddress || !registryABI || !proposalIds.length) {
+      return;
+    }
+
+    // Only use hex (more specifically `bytes32`) id's
+    const safeProposalIds = proposalIds.filter(web3Instance.utils.isHexStrict);
+
+    if (!safeProposalIds.length) {
+      setProposalsVotingAdaptersStatus(AsyncStatus.FULFILLED);
+      setProposalsVotingAdapters([]);
+
+      return;
+    }
+
+    try {
+      const votingAdapterABI = registryABI.find(
+        (ai) => ai.name === 'votingAdapter'
+      );
+
+      if (!votingAdapterABI) {
+        throw new Error(
+          'No "votingAdapter" ABI function was found in the DAO registry ABI.'
+        );
+      }
+
+      // `DaoRegistry.votingAdapter` calls
+      const votingAdapterCalls: MulticallTuple[] = safeProposalIds.map((id) => [
+        registryAddress,
+        votingAdapterABI,
+        [id],
+      ]);
+
+      setProposalsVotingAdaptersStatus(AsyncStatus.PENDING);
+
+      const votingAdapterAddressResults: string[] = await multicall({
+        calls: votingAdapterCalls,
+        web3Instance,
+      });
+
+      const {default: lazyIVotingABI} = await import(
+        '../../../truffle-contracts/IVoting.json'
+      );
+
+      const getAdapterNameABI = (lazyIVotingABI as typeof registryABI).find(
+        (ai) => ai.name === 'getAdapterName'
+      );
+
+      if (!getAdapterNameABI) {
+        throw new Error(
+          'No "getAdapterName" ABI function was found in the IVoting ABI.'
+        );
+      }
+
+      /**
+       * Filter out `safeProposalIds` which are not sponsored (i.e. voting adapter address === `BURN_ADDRESS`).
+       * Filter out `votingAdapterAddressResults` which equal the `BURN_ADDRESS`.
+       *
+       * This ensures these two arrays maintain the same length as they rely on indexes for the
+       * proposals to match up to the array of `multicall` results.
+       */
+
+      const filteredProposalIds = safeProposalIds.filter(
+        (_id, i) => votingAdapterAddressResults[i] !== BURN_ADDRESS
+      );
+
+      const filteredVotingAdapterAddressResults = votingAdapterAddressResults.filter(
+        (a) => a !== BURN_ADDRESS
+      );
+
+      /**
+       * Exit early if there's no voting adapter addresses.
+       * It means no proposals were found to be sponsored
+       */
+      if (!filteredVotingAdapterAddressResults.length) {
+        setProposalsVotingAdaptersStatus(AsyncStatus.FULFILLED);
+        setProposalsVotingAdapters([]);
+
+        return;
+      }
+
+      const votingAdapterNameCalls: MulticallTuple[] = filteredVotingAdapterAddressResults.map(
+        (votingAdapterAddress) => [votingAdapterAddress, getAdapterNameABI, []]
+      );
+
+      const adapterNameResults: VotingAdapterName[] = await multicall({
+        calls: votingAdapterNameCalls,
+        web3Instance,
+      });
+
+      setProposalsVotingAdaptersStatus(AsyncStatus.FULFILLED);
+
+      setProposalsVotingAdapters(
+        await Promise.all(
+          filteredProposalIds.map(
+            async (id, i): Promise<ProposalVotingAdapterTuple> => {
+              const votingAdapterABI = await getVotingAdapterABI(
+                adapterNameResults[i]
+              );
+              const votingAdapterAddress =
+                filteredVotingAdapterAddressResults[i];
+
+              return [
+                id,
+                {
+                  votingAdapterName: adapterNameResults[i],
+                  votingAdapterABI,
+                  votingAdapterAddress,
+                  getWeb3VotingAdapterContract: () =>
+                    new web3Instance.eth.Contract(
+                      votingAdapterABI,
+                      votingAdapterAddress
+                    ),
+                },
+              ];
+            }
+          )
+        )
+      );
+    } catch (error) {
+      setProposalsVotingAdaptersStatus(AsyncStatus.REJECTED);
+      setProposalsVotingAdapters([]);
+      setProposalsVotingAdaptersError(error);
+    }
+  }
 
   return {
     proposalsVotingAdapters,

--- a/src/components/proposals/hooks/useProposalsVotingAdapter.ts
+++ b/src/components/proposals/hooks/useProposalsVotingAdapter.ts
@@ -1,32 +1,18 @@
-import {AbiItem} from 'web3-utils/types';
-import {Contract} from 'web3-eth-contract/types';
+import {useCallback, useEffect, useState} from 'react';
+import {useSelector} from 'react-redux';
 
 import {AsyncStatus} from '../../../util/types';
 import {BURN_ADDRESS} from '../../../util/constants';
 import {getVotingAdapterABI} from '../helpers';
 import {multicall, MulticallTuple} from '../../web3/helpers';
+import {ProposalVotingAdapterData} from '../types';
 import {StoreState} from '../../../store/types';
-import {useCallback, useEffect, useState} from 'react';
-import {useSelector} from 'react-redux';
 import {useWeb3Modal} from '../../web3/hooks';
 import {VotingAdapterName} from '../../adapters-extensions/enums';
 
-type VotingAdapterData = {
-  votingAdapterName: VotingAdapterName;
-  votingAdapterAddress: string;
-  /**
-   * Get the ABI for the proposal.
-   * The object is not included inline to
-   * save from repetitive data (some ABIs can be large).
-   */
-  getVotingAdapterABI: () => AbiItem[];
-  // Helper to use the Web3 Contract directly
-  getWeb3VotingAdapterContract: () => Contract;
-};
-
 type ProposalVotingAdapterTuple = [
   proposalId: string,
-  votingAdapterData: VotingAdapterData
+  votingAdapterData: ProposalVotingAdapterData
 ];
 
 type UseProposalsVotingAdapterReturn = {

--- a/src/components/proposals/hooks/useProposalsVotingAdapter.ts
+++ b/src/components/proposals/hooks/useProposalsVotingAdapter.ts
@@ -14,7 +14,12 @@ import {VotingAdapterName} from '../../adapters-extensions/enums';
 type VotingAdapterData = {
   votingAdapterName: VotingAdapterName;
   votingAdapterAddress: string;
-  votingAdapterABI: AbiItem[];
+  /**
+   * Get the ABI for the proposal.
+   * The object is not included inline to
+   * save from repetitive data (some ABIs can be large).
+   */
+  getVotingAdapterABI: () => AbiItem[];
   // Helper to use the Web3 Contract directly
   getWeb3VotingAdapterContract: () => Contract;
 };
@@ -199,8 +204,8 @@ export function useProposalsVotingAdapter(
                 id,
                 {
                   votingAdapterName: adapterNameResults[i],
-                  votingAdapterABI,
                   votingAdapterAddress,
+                  getVotingAdapterABI: () => votingAdapterABI,
                   getWeb3VotingAdapterContract: () =>
                     new web3Instance.eth.Contract(
                       votingAdapterABI,

--- a/src/components/proposals/hooks/useProposalsVotingAdapter.ts
+++ b/src/components/proposals/hooks/useProposalsVotingAdapter.ts
@@ -21,6 +21,13 @@ type UseProposalsVotingAdapterReturn = {
   proposalsVotingAdaptersStatus: AsyncStatus;
 };
 
+/**
+ * Fetch voting adapter data for proposals by DAO proposal id.
+ * Only returns data for proposals of which voting adapters have been assigned (i.e. sponsored).
+ *
+ * @param {string[]}
+ * @returns {UseProposalsVotingAdapterReturn}
+ */
 export function useProposalsVotingAdapter(
   proposalIds: string[]
 ): UseProposalsVotingAdapterReturn {

--- a/src/components/proposals/hooks/useProposalsVotingAdapter.ts
+++ b/src/components/proposals/hooks/useProposalsVotingAdapter.ts
@@ -1,0 +1,57 @@
+import {AbiItem} from 'web3-utils/types';
+import {Contract} from 'web3-eth-contract/types';
+
+import {AsyncStatus} from '../../../util/types';
+import {useState} from 'react';
+import {VotingAdapterName} from '../../adapters-extensions/enums';
+
+type VotingAdapterData = {
+  votingAdapterName: VotingAdapterName;
+  votingAdapterAddress: string;
+  votingAdapterABI: AbiItem[];
+  // Helper to use the Web3 Contract directly
+  getWeb3VotingAdapterContract: () => Contract;
+};
+
+type ProposalVotingAdapterTuple = [
+  proposalId: string,
+  votingAdapterData: VotingAdapterData
+];
+
+type UseProposalsVotingAdapterReturn = {
+  proposalsVotingAdapters: ProposalVotingAdapterTuple[];
+  proposalsVotingAdaptersError: Error | undefined;
+  proposalsVotingAdaptersStatus: AsyncStatus;
+};
+
+export function useProposalsVotingAdapter(
+  proposalIds: string[]
+): UseProposalsVotingAdapterReturn {
+  /**
+   * State
+   */
+
+  const [proposalsVotingAdapters, setProposalsVotingAdapters] = useState<
+    UseProposalsVotingAdapterReturn['proposalsVotingAdapters']
+  >([]);
+
+  const [
+    proposalsVotingAdaptersError,
+    setProposalsVotingAdaptersError,
+  ] = useState<
+    UseProposalsVotingAdapterReturn['proposalsVotingAdaptersError']
+  >();
+
+  const [
+    proposalsVotingAdaptersStatus,
+    setProposalsVotingAdaptersStatus,
+  ] = useState<
+    UseProposalsVotingAdapterReturn['proposalsVotingAdaptersStatus']
+  >(AsyncStatus.STANDBY);
+
+  return {
+    proposalsVotingAdapters,
+    proposalsVotingAdaptersError,
+    proposalsVotingAdaptersStatus,
+  };
+}

--- a/src/components/proposals/hooks/useProposalsVotingAdapter.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalsVotingAdapter.unit.test.ts
@@ -1,13 +1,81 @@
 import {act, renderHook} from '@testing-library/react-hooks';
-import {AsyncStatus} from '../../../util/types';
 
+import {AsyncStatus} from '../../../util/types';
+import {DEFAULT_ETH_ADDRESS} from '../../../test/helpers';
 import {useProposalsVotingAdapter} from './useProposalsVotingAdapter';
+import {VotingAdapterName} from '../../adapters-extensions/enums';
+import OffchainVotingContractABI from '../../../truffle-contracts/OffchainVotingContract.json';
+import VotingContractABI from '../../../truffle-contracts/VotingContract.json';
+import Wrapper from '../../../test/Wrapper';
 
 describe('useProposalsVotingAdapter unit tests', () => {
   test('should return correct data', async () => {
     await act(async () => {
-      const {result, waitForNextUpdate} = await renderHook(() =>
-        useProposalsVotingAdapter([])
+      const proposalIds = [
+        '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
+        '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca76',
+        '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca77',
+      ];
+
+      const {result, waitForNextUpdate} = await renderHook(
+        () => useProposalsVotingAdapter(proposalIds),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                DEFAULT_ETH_ADDRESS
+              );
+              const votingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                '0xa8ED02b24B4E9912e39337322885b65b23CdF188'
+              );
+
+              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.OffchainVotingContract
+              );
+
+              const votingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.VotingContract
+              );
+
+              // Mock `dao.votingAdapter` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      offchainVotingAdapterResponse,
+                      offchainVotingAdapterResponse,
+                      votingAdapterResponse,
+                    ],
+                  ]
+                )
+              );
+
+              // Mock `IVoting.getAdapterName` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      offchainVotingAdapterNameResponse,
+                      offchainVotingAdapterNameResponse,
+                      votingAdapterNameResponse,
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
       );
 
       // Initial state
@@ -15,6 +83,262 @@ describe('useProposalsVotingAdapter unit tests', () => {
       expect(result.current.proposalsVotingAdaptersError).toBe(undefined);
       expect(result.current.proposalsVotingAdaptersStatus).toBe(
         AsyncStatus.STANDBY
+      );
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposalsVotingAdapters).toMatchObject([]);
+      expect(result.current.proposalsVotingAdaptersError).toBe(undefined);
+      expect(result.current.proposalsVotingAdaptersStatus).toBe(
+        AsyncStatus.PENDING
+      );
+
+      await waitForNextUpdate();
+
+      // Assert first tuple result
+
+      expect(result.current.proposalsVotingAdapters[0][0]).toBe(proposalIds[0]);
+
+      expect(
+        result.current.proposalsVotingAdapters[0][1].votingAdapterABI
+      ).toMatchObject(OffchainVotingContractABI);
+
+      expect(
+        result.current.proposalsVotingAdapters[0][1].votingAdapterAddress
+      ).toBe(DEFAULT_ETH_ADDRESS);
+
+      expect(
+        result.current.proposalsVotingAdapters[0][1].votingAdapterName
+      ).toBe(VotingAdapterName.OffchainVotingContract);
+
+      expect(
+        result.current.proposalsVotingAdapters[0][1]
+          .getWeb3VotingAdapterContract
+      ).toBeInstanceOf(Function);
+
+      // Assert second tuple result
+
+      expect(result.current.proposalsVotingAdapters[1][0]).toBe(proposalIds[1]);
+
+      expect(
+        result.current.proposalsVotingAdapters[1][1].votingAdapterABI
+      ).toMatchObject(OffchainVotingContractABI);
+
+      expect(
+        result.current.proposalsVotingAdapters[1][1].votingAdapterAddress
+      ).toBe(DEFAULT_ETH_ADDRESS);
+
+      expect(
+        result.current.proposalsVotingAdapters[1][1].votingAdapterName
+      ).toBe(VotingAdapterName.OffchainVotingContract);
+
+      expect(
+        result.current.proposalsVotingAdapters[1][1]
+          .getWeb3VotingAdapterContract
+      ).toBeInstanceOf(Function);
+
+      // Assert third tuple result
+
+      expect(result.current.proposalsVotingAdapters[2][0]).toBe(proposalIds[2]);
+
+      expect(
+        result.current.proposalsVotingAdapters[2][1].votingAdapterABI
+      ).toMatchObject(VotingContractABI);
+
+      expect(
+        result.current.proposalsVotingAdapters[2][1].votingAdapterAddress
+      ).toBe('0xa8ED02b24B4E9912e39337322885b65b23CdF188');
+
+      expect(
+        result.current.proposalsVotingAdapters[2][1].votingAdapterName
+      ).toBe(VotingAdapterName.VotingContract);
+
+      expect(
+        result.current.proposalsVotingAdapters[2][1]
+          .getWeb3VotingAdapterContract
+      ).toBeInstanceOf(Function);
+
+      expect(result.current.proposalsVotingAdaptersError).toBe(undefined);
+      expect(result.current.proposalsVotingAdaptersStatus).toBe(
+        AsyncStatus.FULFILLED
+      );
+
+      // Test off-chain `getWeb3VotingAdapterContract` function return result
+
+      expect(
+        result.current.proposalsVotingAdapters[0][1].getWeb3VotingAdapterContract()
+          .methods.submitVoteResult
+      ).toBeDefined();
+
+      // Test on-chain `getWeb3VotingAdapterContract` function return result
+
+      expect(
+        result.current.proposalsVotingAdapters[2][1].getWeb3VotingAdapterContract()
+          .methods.submitVote
+      ).toBeDefined();
+    });
+  });
+
+  test('should not start when no proposal ids', async () => {
+    await act(async () => {
+      const proposalIds = [] as string[];
+
+      const {result, waitForNextUpdate} = await renderHook(
+        () => useProposalsVotingAdapter(proposalIds),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                DEFAULT_ETH_ADDRESS
+              );
+              const votingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                '0xa8ED02b24B4E9912e39337322885b65b23CdF188'
+              );
+
+              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.OffchainVotingContract
+              );
+
+              const votingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.VotingContract
+              );
+
+              // Mock `dao.votingAdapter` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      offchainVotingAdapterResponse,
+                      offchainVotingAdapterResponse,
+                      votingAdapterResponse,
+                    ],
+                  ]
+                )
+              );
+
+              // Mock `IVoting.getAdapterName` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      offchainVotingAdapterNameResponse,
+                      offchainVotingAdapterNameResponse,
+                      votingAdapterNameResponse,
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      // Initial state
+      expect(result.current.proposalsVotingAdapters).toMatchObject([]);
+      expect(result.current.proposalsVotingAdaptersError).toBe(undefined);
+      expect(result.current.proposalsVotingAdaptersStatus).toBe(
+        AsyncStatus.STANDBY
+      );
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposalsVotingAdapters).toMatchObject([]);
+      expect(result.current.proposalsVotingAdaptersError).toBe(undefined);
+      expect(result.current.proposalsVotingAdaptersStatus).toBe(
+        AsyncStatus.STANDBY
+      );
+    });
+  });
+
+  test('should return no data when no bytes32[] proposal ids', async () => {
+    await act(async () => {
+      const proposalIds = ['bad id', 'another bad', 'totally bad'];
+
+      const {result, waitForNextUpdate} = await renderHook(
+        () => useProposalsVotingAdapter(proposalIds),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              const offchainVotingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                DEFAULT_ETH_ADDRESS
+              );
+              const votingAdapterResponse = web3Instance.eth.abi.encodeParameter(
+                'address',
+                '0xa8ED02b24B4E9912e39337322885b65b23CdF188'
+              );
+
+              const offchainVotingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.OffchainVotingContract
+              );
+
+              const votingAdapterNameResponse = web3Instance.eth.abi.encodeParameter(
+                'string',
+                VotingAdapterName.VotingContract
+              );
+
+              // Mock `dao.votingAdapter` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      offchainVotingAdapterResponse,
+                      offchainVotingAdapterResponse,
+                      votingAdapterResponse,
+                    ],
+                  ]
+                )
+              );
+
+              // Mock `IVoting.getAdapterName` responses
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      offchainVotingAdapterNameResponse,
+                      offchainVotingAdapterNameResponse,
+                      votingAdapterNameResponse,
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      // Initial state
+      expect(result.current.proposalsVotingAdapters).toMatchObject([]);
+      expect(result.current.proposalsVotingAdaptersError).toBe(undefined);
+      expect(result.current.proposalsVotingAdaptersStatus).toBe(
+        AsyncStatus.STANDBY
+      );
+
+      await waitForNextUpdate();
+
+      expect(result.current.proposalsVotingAdapters).toMatchObject([]);
+      expect(result.current.proposalsVotingAdaptersError).toBe(undefined);
+      expect(result.current.proposalsVotingAdaptersStatus).toBe(
+        AsyncStatus.FULFILLED
       );
     });
   });

--- a/src/components/proposals/hooks/useProposalsVotingAdapter.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalsVotingAdapter.unit.test.ts
@@ -100,7 +100,7 @@ describe('useProposalsVotingAdapter unit tests', () => {
       expect(result.current.proposalsVotingAdapters[0][0]).toBe(proposalIds[0]);
 
       expect(
-        result.current.proposalsVotingAdapters[0][1].votingAdapterABI
+        result.current.proposalsVotingAdapters[0][1].getVotingAdapterABI()
       ).toMatchObject(OffchainVotingContractABI);
 
       expect(
@@ -112,16 +112,16 @@ describe('useProposalsVotingAdapter unit tests', () => {
       ).toBe(VotingAdapterName.OffchainVotingContract);
 
       expect(
-        result.current.proposalsVotingAdapters[0][1]
-          .getWeb3VotingAdapterContract
-      ).toBeInstanceOf(Function);
+        result.current.proposalsVotingAdapters[0][1].getWeb3VotingAdapterContract()
+          .methods.submitVoteResult
+      ).toBeDefined();
 
       // Assert second tuple result
 
       expect(result.current.proposalsVotingAdapters[1][0]).toBe(proposalIds[1]);
 
       expect(
-        result.current.proposalsVotingAdapters[1][1].votingAdapterABI
+        result.current.proposalsVotingAdapters[1][1].getVotingAdapterABI()
       ).toMatchObject(OffchainVotingContractABI);
 
       expect(
@@ -133,16 +133,16 @@ describe('useProposalsVotingAdapter unit tests', () => {
       ).toBe(VotingAdapterName.OffchainVotingContract);
 
       expect(
-        result.current.proposalsVotingAdapters[1][1]
-          .getWeb3VotingAdapterContract
-      ).toBeInstanceOf(Function);
+        result.current.proposalsVotingAdapters[1][1].getWeb3VotingAdapterContract()
+          .methods.submitVoteResult
+      ).toBeDefined();
 
       // Assert third tuple result
 
       expect(result.current.proposalsVotingAdapters[2][0]).toBe(proposalIds[2]);
 
       expect(
-        result.current.proposalsVotingAdapters[2][1].votingAdapterABI
+        result.current.proposalsVotingAdapters[2][1].getVotingAdapterABI()
       ).toMatchObject(VotingContractABI);
 
       expect(
@@ -154,28 +154,14 @@ describe('useProposalsVotingAdapter unit tests', () => {
       ).toBe(VotingAdapterName.VotingContract);
 
       expect(
-        result.current.proposalsVotingAdapters[2][1]
-          .getWeb3VotingAdapterContract
-      ).toBeInstanceOf(Function);
+        result.current.proposalsVotingAdapters[2][1].getWeb3VotingAdapterContract()
+          .methods.submitVote
+      ).toBeDefined();
 
       expect(result.current.proposalsVotingAdaptersError).toBe(undefined);
       expect(result.current.proposalsVotingAdaptersStatus).toBe(
         AsyncStatus.FULFILLED
       );
-
-      // Test off-chain `getWeb3VotingAdapterContract` function return result
-
-      expect(
-        result.current.proposalsVotingAdapters[0][1].getWeb3VotingAdapterContract()
-          .methods.submitVoteResult
-      ).toBeDefined();
-
-      // Test on-chain `getWeb3VotingAdapterContract` function return result
-
-      expect(
-        result.current.proposalsVotingAdapters[2][1].getWeb3VotingAdapterContract()
-          .methods.submitVote
-      ).toBeDefined();
     });
   });
 

--- a/src/components/proposals/hooks/useProposalsVotingAdapter.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalsVotingAdapter.unit.test.ts
@@ -1,0 +1,21 @@
+import {act, renderHook} from '@testing-library/react-hooks';
+import {AsyncStatus} from '../../../util/types';
+
+import {useProposalsVotingAdapter} from './useProposalsVotingAdapter';
+
+describe('useProposalsVotingAdapter unit tests', () => {
+  test('should return correct data', async () => {
+    await act(async () => {
+      const {result, waitForNextUpdate} = await renderHook(() =>
+        useProposalsVotingAdapter([])
+      );
+
+      // Initial state
+      expect(result.current.proposalsVotingAdapters).toMatchObject([]);
+      expect(result.current.proposalsVotingAdaptersError).toBe(undefined);
+      expect(result.current.proposalsVotingAdaptersStatus).toBe(
+        AsyncStatus.STANDBY
+      );
+    });
+  });
+});

--- a/src/components/proposals/hooks/useProposalsVotingState.ts
+++ b/src/components/proposals/hooks/useProposalsVotingState.ts
@@ -64,25 +64,24 @@ export function useProposalsVotingState(
    * Cached callbacks
    */
 
-  const getProposalsVotingStateCached = useCallback(getProposalsVotingState, [
-    proposalVotingAdapters,
-    registryAddress,
-    web3Instance,
-  ]);
+  const getProposalsVotingStateOnchainCached = useCallback(
+    getProposalsVotingStateOnchain,
+    [proposalVotingAdapters, registryAddress, web3Instance]
+  );
 
   /**
    * Effects
    */
 
   useEffect(() => {
-    getProposalsVotingStateCached();
-  }, [getProposalsVotingStateCached]);
+    getProposalsVotingStateOnchainCached();
+  }, [getProposalsVotingStateOnchainCached]);
 
   /**
    * Functions
    */
 
-  async function getProposalsVotingState() {
+  async function getProposalsVotingStateOnchain() {
     if (!registryAddress || !proposalVotingAdapters.length) {
       return;
     }

--- a/src/components/proposals/hooks/useProposalsVotingState.ts
+++ b/src/components/proposals/hooks/useProposalsVotingState.ts
@@ -1,8 +1,10 @@
 import {useCallback, useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
+import {AbiItem} from 'web3-utils/types';
 
 import {AsyncStatus} from '../../../util/types';
 import {multicall, MulticallTuple} from '../../web3/helpers';
+import {ProposalVotingAdapterTuple} from '../types';
 import {StoreState} from '../../../store/types';
 import {useWeb3Modal} from '../../web3/hooks';
 import {VotingState} from '../voting/types';
@@ -19,7 +21,11 @@ type UseProposalsVotingStateReturn = {
 };
 
 export function useProposalsVotingState(
-  proposalIds: string[]
+  /**
+   * A tuple of proposal id's and voting adapter data.
+   * This data is returned by `useProposalsVotingAdapter`.
+   */
+  proposalVotingAdapters: ProposalVotingAdapterTuple[]
 ): UseProposalsVotingStateReturn {
   /**
    * Selectors
@@ -27,12 +33,6 @@ export function useProposalsVotingState(
 
   const registryAddress = useSelector(
     (s: StoreState) => s.contracts.DaoRegistryContract?.contractAddress
-  );
-  const votingAddress = useSelector(
-    (s: StoreState) => s.contracts.VotingContract?.contractAddress
-  );
-  const votingABI = useSelector(
-    (s: StoreState) => s.contracts.VotingContract?.abi
   );
 
   /**
@@ -65,10 +65,8 @@ export function useProposalsVotingState(
    */
 
   const getProposalsVotingStateCached = useCallback(getProposalsVotingState, [
-    proposalIds,
+    proposalVotingAdapters,
     registryAddress,
-    votingABI,
-    votingAddress,
     web3Instance,
   ]);
 
@@ -85,38 +83,43 @@ export function useProposalsVotingState(
    */
 
   async function getProposalsVotingState() {
-    if (
-      !registryAddress ||
-      !votingAddress ||
-      !votingABI ||
-      !proposalIds.length
-    ) {
+    if (!registryAddress || !proposalVotingAdapters.length) {
       return;
     }
 
     // Only use hex (more specifically `bytes32`) id's
-    const safeProposalIds = proposalIds.filter(web3Instance.utils.isHexStrict);
+    const safeProposalVotingAdapters = proposalVotingAdapters.filter(([id]) =>
+      web3Instance.utils.isHexStrict(id)
+    );
 
-    if (!safeProposalIds.length) {
+    if (!safeProposalVotingAdapters.length) {
       setProposalsVotingStateStatus(AsyncStatus.FULFILLED);
 
       return;
     }
 
     try {
-      const votingResultAbi = votingABI.find((ai) => ai.name === 'voteResult');
+      const lazyIVotingABI = (
+        await import('../../../truffle-contracts/IVoting.json')
+      ).default as AbiItem[];
+
+      const votingResultAbi = lazyIVotingABI.find(
+        (ai) => ai.name === 'voteResult'
+      );
 
       if (!votingResultAbi) {
         throw new Error(
-          'No "voteResult" ABI function was found for the voting adapter.'
+          'No "voteResult" ABI function was found on the "IVoting" contract.'
         );
       }
 
-      const calls: MulticallTuple[] = safeProposalIds.map((id) => [
-        votingAddress,
-        votingResultAbi,
-        [registryAddress, id],
-      ]);
+      const calls: MulticallTuple[] = safeProposalVotingAdapters.map(
+        ([proposalId, {votingAdapterAddress}]) => [
+          votingAdapterAddress,
+          votingResultAbi,
+          [registryAddress, proposalId],
+        ]
+      );
 
       setProposalsVotingStateStatus(AsyncStatus.PENDING);
 
@@ -127,7 +130,10 @@ export function useProposalsVotingState(
 
       setProposalsVotingStateStatus(AsyncStatus.FULFILLED);
       setProposaslsVotingState(
-        safeProposalIds.map((id, i) => [id, proposalsVotingStateResult[i]])
+        safeProposalVotingAdapters.map(([proposalId], i) => [
+          proposalId,
+          proposalsVotingStateResult[i],
+        ])
       );
     } catch (error) {
       setProposalsVotingStateStatus(AsyncStatus.REJECTED);

--- a/src/components/proposals/hooks/useProposalsVotingState.unit.test.tsx
+++ b/src/components/proposals/hooks/useProposalsVotingState.unit.test.tsx
@@ -1,21 +1,46 @@
 import {renderHook, act} from '@testing-library/react-hooks';
+import {AbiItem} from 'web3-utils/types';
 
-import {useProposalsVotingState} from './useProposalsVotingState';
-import Wrapper from '../../../test/Wrapper';
-import {DEFAULT_PROPOSAL_HASH} from '../../../test/helpers';
+import {
+  DEFAULT_ETH_ADDRESS,
+  DEFAULT_PROPOSAL_HASH,
+} from '../../../test/helpers';
 import {AsyncStatus} from '../../../util/types';
+import {ProposalVotingAdapterData, ProposalVotingAdapterTuple} from '../types';
+import {useProposalsVotingState} from './useProposalsVotingState';
+import {VotingAdapterName} from '../../adapters-extensions/enums';
+import Wrapper from '../../../test/Wrapper';
 
 describe('useProposalsVotingState unit tests', () => {
-  const proposalIds = [
-    DEFAULT_PROPOSAL_HASH,
-    DEFAULT_PROPOSAL_HASH,
-    DEFAULT_PROPOSAL_HASH,
-  ];
+  /**
+   * `useProposalsVotingState` uses the `IVoting` contract interally,
+   * so we don't need to be concered anbout setting an ABI in the test data.
+   * We just need to make sure we can pass different addresses for `votingAdapterAddress`.
+   */
+  const defaultVotingAdapterData: ProposalVotingAdapterData = {
+    votingAdapterAddress: DEFAULT_ETH_ADDRESS,
+    votingAdapterName: VotingAdapterName.OffchainVotingContract,
+    getVotingAdapterABI: () => [] as AbiItem[],
+    getWeb3VotingAdapterContract: () => undefined as any,
+  };
 
   test('should return correct hook state', async () => {
+    const proposalsVotingAdapterTuples: ProposalVotingAdapterTuple[] = [
+      [DEFAULT_PROPOSAL_HASH, defaultVotingAdapterData],
+      [DEFAULT_PROPOSAL_HASH, defaultVotingAdapterData],
+      // Set another voting adapter address to be safe
+      [
+        DEFAULT_PROPOSAL_HASH,
+        {
+          ...defaultVotingAdapterData,
+          votingAdapterAddress: '0xa8ED02b24B4E9912e39337322885b65b23CdF188',
+        },
+      ],
+    ];
+
     await act(async () => {
-      const {result, waitForNextUpdate} = await renderHook(
-        () => useProposalsVotingState(proposalIds),
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalsVotingState(proposalsVotingAdapterTuples),
         {
           wrapper: Wrapper,
           initialProps: {
@@ -47,65 +72,52 @@ describe('useProposalsVotingState unit tests', () => {
       expect(result.current.proposalsVotingStateStatus).toBe(
         AsyncStatus.STANDBY
       );
-
       expect(result.current.proposalsVotingStateError).toBe(undefined);
       expect(result.current.proposalsVotingState).toMatchObject([]);
 
-      await waitForNextUpdate();
-
-      expect(result.current.proposalsVotingStateStatus).toBe(
-        AsyncStatus.STANDBY
+      await waitForValueToChange(
+        () => result.current.proposalsVotingStateStatus
       );
-
-      expect(result.current.proposalsVotingStateError).toBe(undefined);
-      expect(result.current.proposalsVotingState).toMatchObject([]);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposalsVotingStateStatus).toBe(
-        AsyncStatus.STANDBY
-      );
-
-      expect(result.current.proposalsVotingStateError).toBe(undefined);
-      expect(result.current.proposalsVotingState).toMatchObject([]);
-
-      await waitForNextUpdate();
 
       expect(result.current.proposalsVotingStateStatus).toBe(
         AsyncStatus.PENDING
       );
-
+      expect(result.current.proposalsVotingStateError).toBe(undefined);
       expect(result.current.proposalsVotingState).toMatchObject([]);
 
-      await waitForNextUpdate();
+      await waitForValueToChange(
+        () => result.current.proposalsVotingStateStatus
+      );
 
       expect(result.current.proposalsVotingStateStatus).toBe(
         AsyncStatus.FULFILLED
       );
 
       expect(result.current.proposalsVotingState).toMatchObject([
-        [
-          '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
-          '0',
-        ],
-        [
-          '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
-          '2',
-        ],
-        [
-          '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
-          '3',
-        ],
+        [DEFAULT_PROPOSAL_HASH, '0'],
+        [DEFAULT_PROPOSAL_HASH, '2'],
+        [DEFAULT_PROPOSAL_HASH, '3'],
       ]);
     });
   });
 
   test('should return empty result if every proposalIds is not bytes32[]', async () => {
-    const badProposalIds = ['abc123', 'abc456'];
+    const badProposalsVotingAdapterTuples: ProposalVotingAdapterTuple[] = [
+      ['abc123', defaultVotingAdapterData],
+      ['abc456', defaultVotingAdapterData],
+      // Set another voting adapter address to be safe
+      [
+        'abc789',
+        {
+          ...defaultVotingAdapterData,
+          votingAdapterAddress: '0xa8ED02b24B4E9912e39337322885b65b23CdF188',
+        },
+      ],
+    ];
 
     await act(async () => {
-      const {result, waitForNextUpdate} = await renderHook(
-        () => useProposalsVotingState(badProposalIds),
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalsVotingState(badProposalsVotingAdapterTuples),
         {
           wrapper: Wrapper,
           initialProps: {
@@ -137,45 +149,98 @@ describe('useProposalsVotingState unit tests', () => {
       expect(result.current.proposalsVotingStateStatus).toBe(
         AsyncStatus.STANDBY
       );
-
       expect(result.current.proposalsVotingStateError).toBe(undefined);
       expect(result.current.proposalsVotingState).toMatchObject([]);
 
-      await waitForNextUpdate();
-
-      expect(result.current.proposalsVotingStateStatus).toBe(
-        AsyncStatus.STANDBY
+      await waitForValueToChange(
+        () => result.current.proposalsVotingStateStatus
       );
-
-      expect(result.current.proposalsVotingStateError).toBe(undefined);
-      expect(result.current.proposalsVotingState).toMatchObject([]);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposalsVotingStateStatus).toBe(
-        AsyncStatus.STANDBY
-      );
-
-      expect(result.current.proposalsVotingStateError).toBe(undefined);
-      expect(result.current.proposalsVotingState).toMatchObject([]);
-
-      await waitForNextUpdate();
 
       expect(result.current.proposalsVotingStateStatus).toBe(
         AsyncStatus.FULFILLED
       );
-
       expect(result.current.proposalsVotingStateError).toBe(undefined);
       expect(result.current.proposalsVotingState).toMatchObject([]);
     });
   });
 
+  test('should return correct hook state if only some proposalIds is bytes32[]', async () => {
+    const badProposalsVotingAdapterTuples: ProposalVotingAdapterTuple[] = [
+      [DEFAULT_PROPOSAL_HASH, defaultVotingAdapterData],
+      ['abc456', defaultVotingAdapterData],
+      // Set another voting adapter address to be safe
+      [
+        'abc789',
+        {
+          ...defaultVotingAdapterData,
+          votingAdapterAddress: '0xa8ED02b24B4E9912e39337322885b65b23CdF188',
+        },
+      ],
+    ];
+
+    await act(async () => {
+      const {result, waitForValueToChange} = await renderHook(
+        () => useProposalsVotingState(badProposalsVotingAdapterTuples),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: ({mockWeb3Provider, web3Instance}) => {
+              // Mock proposals' voting state multicall response
+              mockWeb3Provider.injectResult(
+                web3Instance.eth.abi.encodeParameters(
+                  ['uint256', 'bytes[]'],
+                  [
+                    0,
+                    [
+                      // VotingState.PASS
+                      web3Instance.eth.abi.encodeParameter('uint8', '2'),
+                    ],
+                  ]
+                )
+              );
+            },
+          },
+        }
+      );
+
+      expect(result.current.proposalsVotingStateStatus).toBe(
+        AsyncStatus.STANDBY
+      );
+      expect(result.current.proposalsVotingStateError).toBe(undefined);
+      expect(result.current.proposalsVotingState).toMatchObject([]);
+
+      await waitForValueToChange(
+        () => result.current.proposalsVotingStateStatus
+      );
+
+      expect(result.current.proposalsVotingStateStatus).toBe(
+        AsyncStatus.PENDING
+      );
+      expect(result.current.proposalsVotingStateError).toBe(undefined);
+      expect(result.current.proposalsVotingState).toMatchObject([]);
+
+      await waitForValueToChange(
+        () => result.current.proposalsVotingStateStatus
+      );
+
+      expect(result.current.proposalsVotingStateStatus).toBe(
+        AsyncStatus.FULFILLED
+      );
+      expect(result.current.proposalsVotingStateError).toBe(undefined);
+      expect(result.current.proposalsVotingState).toMatchObject([
+        [DEFAULT_PROPOSAL_HASH, '2'],
+      ]);
+    });
+  });
+
   test('should not run if empty array of proposalIds', async () => {
-    const emptyProposalIds: string[] = [];
+    const emptyProposalsVotingAdapterTuples = [] as ProposalVotingAdapterTuple[];
 
     await act(async () => {
       const {result, waitForNextUpdate} = await renderHook(
-        () => useProposalsVotingState(emptyProposalIds),
+        () => useProposalsVotingState(emptyProposalsVotingAdapterTuples),
         {
           wrapper: Wrapper,
           initialProps: {
@@ -207,29 +272,16 @@ describe('useProposalsVotingState unit tests', () => {
       expect(result.current.proposalsVotingStateStatus).toBe(
         AsyncStatus.STANDBY
       );
-
       expect(result.current.proposalsVotingStateError).toBe(undefined);
-
       expect(result.current.proposalsVotingState).toMatchObject([]);
 
       await waitForNextUpdate();
 
+      // Assert no changes
       expect(result.current.proposalsVotingStateStatus).toBe(
         AsyncStatus.STANDBY
       );
-
       expect(result.current.proposalsVotingStateError).toBe(undefined);
-
-      expect(result.current.proposalsVotingState).toMatchObject([]);
-
-      await waitForNextUpdate();
-
-      expect(result.current.proposalsVotingStateStatus).toBe(
-        AsyncStatus.STANDBY
-      );
-
-      expect(result.current.proposalsVotingStateError).toBe(undefined);
-
       expect(result.current.proposalsVotingState).toMatchObject([]);
     });
   });

--- a/src/components/proposals/hooks/useProposalsVotingState.unit.test.tsx
+++ b/src/components/proposals/hooks/useProposalsVotingState.unit.test.tsx
@@ -14,7 +14,7 @@ import Wrapper from '../../../test/Wrapper';
 describe('useProposalsVotingState unit tests', () => {
   /**
    * `useProposalsVotingState` uses the `IVoting` contract interally,
-   * so we don't need to be concered anbout setting an ABI in the test data.
+   * so we don't need to be concerned about setting an ABI in the test data.
    * We just need to make sure we can pass different addresses for `votingAdapterAddress`.
    */
   const defaultVotingAdapterData: ProposalVotingAdapterData = {

--- a/src/components/proposals/types.ts
+++ b/src/components/proposals/types.ts
@@ -6,6 +6,10 @@ import {
   SnapshotType,
   VoteChoices,
 } from '@openlaw/snapshot-js-erc712';
+import {AbiItem} from 'web3-utils/types';
+import {Contract} from 'web3-eth-contract/types';
+
+import {VotingAdapterName} from '../adapters-extensions/enums';
 
 /**
  * ENUMS
@@ -105,6 +109,10 @@ export type SnapshotProposal = {
 export type SnapshotProposalCommon = SnapshotDraft | SnapshotProposal;
 
 export type ProposalData = {
+  // @todo Make non-nullable
+  idInDAO?: string;
+  // @todo Make non-nullable
+  daoProposalVotingAdapter?: ProposalVotingAdapterData;
   daoProposal: Proposal | undefined;
   /**
    * Data for either a Draft or Proposal which is shared between the two types.
@@ -185,4 +193,20 @@ export type VotingResult = {
   [VoteChoices.Yes]: VoteChoiceResult;
   [VoteChoices.No]: VoteChoiceResult;
   totalShares: number;
+};
+
+/**
+ * Proposal's voting adapter data
+ */
+export type ProposalVotingAdapterData = {
+  votingAdapterName: VotingAdapterName;
+  votingAdapterAddress: string;
+  /**
+   * Get the ABI for the proposal.
+   * The object is not included inline to
+   * save from repetitive data (some ABIs can be large).
+   */
+  getVotingAdapterABI: () => AbiItem[];
+  // Helper to use the Web3 Contract directly
+  getWeb3VotingAdapterContract: () => Contract;
 };

--- a/src/components/proposals/types.ts
+++ b/src/components/proposals/types.ts
@@ -115,6 +115,8 @@ export type ProposalData = {
   // @todo Make non-nullable?
   daoProposalVotingAdapter?: ProposalVotingAdapterData;
   // @todo Make non-nullable?
+  daoProposalVotes?: ProposalVotesData;
+  // @todo Make non-nullable?
   daoProposalVotingState?: VotingState;
   daoProposal: Proposal | undefined;
   /**
@@ -218,3 +220,13 @@ export type ProposalVotingAdapterTuple = [
   proposalId: string,
   votingAdapterData: ProposalVotingAdapterData
 ];
+
+/**
+ * Proposal on-chain votes data
+ *
+ * @see `useProposalsVotes`
+ */
+export type ProposalVotesData = {
+  [VotingAdapterName.OffchainVotingContract]?: OffchainVotingAdapterVotes;
+  [VotingAdapterName.VotingContract]?: VotingAdapterVotes;
+};

--- a/src/components/proposals/types.ts
+++ b/src/components/proposals/types.ts
@@ -10,6 +10,7 @@ import {AbiItem} from 'web3-utils/types';
 import {Contract} from 'web3-eth-contract/types';
 
 import {VotingAdapterName} from '../adapters-extensions/enums';
+import {VotingState} from './voting/types';
 
 /**
  * ENUMS
@@ -109,10 +110,12 @@ export type SnapshotProposal = {
 export type SnapshotProposalCommon = SnapshotDraft | SnapshotProposal;
 
 export type ProposalData = {
-  // @todo Make non-nullable
+  // @todo Make non-nullable?
   idInDAO?: string;
-  // @todo Make non-nullable
+  // @todo Make non-nullable?
   daoProposalVotingAdapter?: ProposalVotingAdapterData;
+  // @todo Make non-nullable?
+  daoProposalVotingState?: VotingState;
   daoProposal: Proposal | undefined;
   /**
    * Data for either a Draft or Proposal which is shared between the two types.
@@ -210,3 +213,8 @@ export type ProposalVotingAdapterData = {
   // Helper to use the Web3 Contract directly
   getWeb3VotingAdapterContract: () => Contract;
 };
+
+export type ProposalVotingAdapterTuple = [
+  proposalId: string,
+  votingAdapterData: ProposalVotingAdapterData
+];

--- a/src/components/proposals/voting/OffchainOpRollupVotingSubmitResultAction.tsx
+++ b/src/components/proposals/voting/OffchainOpRollupVotingSubmitResultAction.tsx
@@ -53,7 +53,7 @@ export function OffchainOpRollupVotingSubmitResultAction(
 ) {
   const {
     adapterName,
-    proposal: {snapshotProposal},
+    proposal: {daoProposalVotingAdapter, snapshotProposal},
   } = props;
 
   /**
@@ -71,9 +71,6 @@ export function OffchainOpRollupVotingSubmitResultAction(
 
   const bankExtensionMethods = useSelector(
     (s: StoreState) => s.contracts.BankExtensionContract?.instance.methods
-  );
-  const offchainVotingMethods = useSelector(
-    (s: StoreState) => s.contracts.VotingContract?.instance.methods
   );
   const daoRegistryAddress = useSelector(
     (s: StoreState) => s.contracts.DaoRegistryContract?.contractAddress
@@ -99,6 +96,9 @@ export function OffchainOpRollupVotingSubmitResultAction(
   /**
    * Variables
    */
+
+  const votingAdapterMethods = daoProposalVotingAdapter?.getWeb3VotingAdapterContract()
+    .methods;
 
   const isInProcess =
     signatureStatus === Web3TxStatus.AWAITING_CONFIRM ||
@@ -128,6 +128,10 @@ export function OffchainOpRollupVotingSubmitResultAction(
 
       if (!snapshotProposal.votes) {
         throw new Error('No Snapshot proposal votes were found.');
+      }
+
+      if (!votingAdapterMethods) {
+        throw new Error('No "OffchainVotingContract" methods were found.');
       }
 
       setSignatureStatus(Web3TxStatus.AWAITING_CONFIRM);
@@ -214,7 +218,7 @@ export function OffchainOpRollupVotingSubmitResultAction(
       // 4. Send the tx
       await txSend(
         'submitVoteResult',
-        offchainVotingMethods,
+        votingAdapterMethods,
         submitVoteResultArguments,
         txArguments
       );


### PR DESCRIPTION
Fixes #248 

🥳  **Adds**

 - `useProposalsVotingAdapter` hook
   - Unit tests
 - `getVotingAdapterABI` helper
   - Unit tests
 - `getVotingAdapterABI` helper + unit test(s)
 - `useProposalWithOffchainVoteStatus` unit tests
 - `ProposalVotesData` type
 - `ProposalVotingAdapterTuple` type
 - `ProposalVotingAdapterData` type
 
✨. **Updates**

 - Uses `getVotingAdapterABI` in `useProposalsVotes`
 - Sets proposals votes to `[]` if no `bytes32[]` proposal ids in `useProposalsVotes`
 - Governance details now render `OffchainVotingStatus` via `ProposalCard` render prop
   - Unit test(s) updated
 - Renders `ProposalActions` using proposal's voting adapter, or DAO's if does not yet exist (e.g. not yet sponsored); updates unit test
 - Updates `ProposalCard` to render the status via a render prop for better flexibility; updates unit test(s)
 - Moves logic for getting voting adapter and votes data from `Proposals` to `useProposals`; updates unit test(s)
 - `Proposals` now renders `ProposalCard` status via render prop
 - `useProposalOrDraft` now fetches voting adapter info via `useProposalsVotingAdapter` and includes it in its return data.
   - Status and error handling now handles multiple async hooks.
 - `useProposalWithOffchainVoteStatus` now uses proposal's `daoProposalVotingAdapter` data to look up info.
   - Error handling added for fetching, and poll fetching
   - Now only gets DAO proposal data if there is no `proposal.daoProposalVotingAdapter` (e.g. not sponsored)
   - `offchainResultSubmitted` bug fix where it was checking the `resultRoot` against wrong length of hash - and did not need to check it in the first place.
   - Status and error handling now handles multiple async hooks.
 - `useProposals` now uses data from `useProposalsVotingAdapter`, `useProposalsVotingState`, `useProposalsVotes` for more complete information
   - Status and error handling now handles multiple async hooks.
   - Updates unit tests
- Refactors `useProposalsVotes` to accept `proposalVotingAdapters` argument to simplify logic and not repeat what has already been fetched / can be fetched by another hook.
  -  Updates unit tests
- Refactors `useProposalsVotingState` to accept `proposalVotingAdapters` argument to simplify logic and not repeat what has already been fetched / can be fetched by another hook.
  -  Updates unit tests
- `ProposalData` type now includes keys for `idInDAO`, `daoProposalVotingAdapter`, `daoProposalVotes`, `daoProposalVotingState`
- `OffchainOpRollupVotingSubmitResultAction` now uses proposal's voting adapter data
  - Unit test(s) updated
 
🐞  **Bugs squashed**

 - `Proposals` would not render error in some cases due to render order logic

🧹  **Chores done**
 
 - Various import cleanup; line breaks added; comments
 - Various React async effect cleanup
