### PR TITLE
Fixes voting voting adapter data not refetching on proposal refetch

### DIFF
--- a/src/components/proposals/hooks/useProposalOrDraft.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalOrDraft.unit.test.ts
@@ -666,7 +666,7 @@ describe('useProposalOrDraft unit tests', () => {
         ]
       );
 
-      const {result, waitForNextUpdate} = await renderHook(
+      const {result, waitForValueToChange} = await renderHook(
         () => useProposalOrDraft(DEFAULT_DRAFT_HASH),
         {
           wrapper: Wrapper,
@@ -706,7 +706,9 @@ describe('useProposalOrDraft unit tests', () => {
       // Request refetch
       result.current.proposalData?.refetchProposalOrDraft();
 
-      await waitForNextUpdate();
+      await waitForValueToChange(
+        () => result.current.proposalData?.snapshotProposal
+      );
 
       expect(result.current.proposalData?.snapshotProposal).toStrictEqual({
         ...proposal,

--- a/src/components/proposals/hooks/useProposalOrDraft.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalOrDraft.unit.test.ts
@@ -666,7 +666,7 @@ describe('useProposalOrDraft unit tests', () => {
         ]
       );
 
-      const {rerender, result} = await renderHook(
+      const {rerender, result, waitForNextUpdate} = await renderHook(
         () => useProposalOrDraft(DEFAULT_DRAFT_HASH),
         {
           wrapper: Wrapper,
@@ -698,6 +698,7 @@ describe('useProposalOrDraft unit tests', () => {
         undefined
       );
 
+      // Set up mock REST response for refetch
       server.use(
         ...[
           rest.get(
@@ -710,11 +711,19 @@ describe('useProposalOrDraft unit tests', () => {
       rerender({
         useInit: true,
         useWallet: true,
+        // Set up mock Web3 responses for refetch
         getProps: mockWeb3ResponsesProposal,
       });
 
+      expect(result.current.proposalData?.snapshotProposal).toBe(undefined);
+      expect(result.current.proposalData?.daoProposalVotingAdapter).toBe(
+        undefined
+      );
+
       // Request refetch
       result.current.proposalData?.refetchProposalOrDraft();
+
+      await waitForNextUpdate();
 
       // Should not be `AsyncStatus.PENDING` on refetch
       expect(result.current.proposalStatus).toBe(AsyncStatus.FULFILLED);


### PR DESCRIPTION
Fixes #268 

✨ **Updates**

 - `useProposalOrDraft` passes new `string[]` reference to `useProposalsVotingAdapter` to force a re-render
 - `useProposalOrDraft` handles refetching logic for `AsyncStatus.PENDING` inside of inclusive status effect to prevent UI spinner from showing again on refetch (silent).
 
🐞 **Bugs squashed**

 - Proposal's voting adapter data was not refetched when the proposal was during the proposal flow.
   - Updates unit test for refetching