### PR TITLE
Update proposals to handle new adapter updates

### DIFF
--- a/src/components/proposals/ProcessAction.tsx
+++ b/src/components/proposals/ProcessAction.tsx
@@ -1,9 +1,9 @@
-import React, {useState} from 'react';
+import {useState, useRef, useEffect} from 'react';
 import {useSelector} from 'react-redux';
 
 import {CycleEllipsis} from '../feedback';
 import {getContractByAddress} from '../web3/helpers';
-import {ProposalData} from './types';
+import {ProposalData, SnapshotProposal} from './types';
 import {StoreState} from '../../store/types';
 import {TX_CYCLE_MESSAGES} from '../web3/config';
 import {useContractSend, useETHGasPrice, useWeb3Modal} from '../web3/hooks';
@@ -23,6 +23,11 @@ type ProcessArguments = [
 type ProcessActionProps = {
   disabled?: boolean;
   proposal: ProposalData;
+  isProposalPassed: boolean;
+};
+
+type ActionDisabledReasons = {
+  notProposerMessage: string;
 };
 
 /**
@@ -40,6 +45,7 @@ export default function ProcessAction(props: ProcessActionProps) {
   const {
     disabled: propsDisabled,
     proposal: {snapshotProposal},
+    isProposalPassed,
   } = props;
 
   /**
@@ -47,6 +53,14 @@ export default function ProcessAction(props: ProcessActionProps) {
    */
 
   const [submitError, setSubmitError] = useState<Error>();
+
+  /**
+   * Refs
+   */
+
+  const actionDisabledReasonsRef = useRef<ActionDisabledReasons>({
+    notProposerMessage: '',
+  });
 
   /**
    * Selectors
@@ -69,6 +83,7 @@ export default function ProcessAction(props: ProcessActionProps) {
     isDisabled,
     openWhyDisabledModal,
     WhyDisabledModal,
+    setOtherDisabledReasons,
   } = useMemberActionDisabled(useMemberActionDisabledProps);
 
   const gasPrices = useETHGasPrice();
@@ -84,6 +99,42 @@ export default function ProcessAction(props: ProcessActionProps) {
   const isDone = txStatus === Web3TxStatus.FULFILLED;
   const isInProcessOrDone = isInProcess || isDone || txIsPromptOpen;
   const areSomeDisabled = isDisabled || isInProcessOrDone || propsDisabled;
+
+  /**
+   * Effects
+   */
+
+  useEffect(() => {
+    // 1. Determine and set reasons why action would be disabled
+
+    // Reason: For some proposal types, a passed proposal can only be
+    // processed by its original proposer (e.g., the owner of the asset to be
+    // transferred)
+
+    // Proposals with this restriction will have this value stored in its
+    // snapshot metadata.
+    const {
+      accountAuthorizedToProcessPassedProposal,
+    } = (snapshotProposal as SnapshotProposal).msg.payload.metadata;
+
+    if (
+      isProposalPassed &&
+      accountAuthorizedToProcessPassedProposal &&
+      account
+    ) {
+      actionDisabledReasonsRef.current = {
+        ...actionDisabledReasonsRef.current,
+        notProposerMessage:
+          accountAuthorizedToProcessPassedProposal.toLowerCase() !==
+          account.toLowerCase()
+            ? 'The passed proposal can be processed only by its original proposer.'
+            : '',
+      };
+    }
+
+    // 2. Set reasons
+    setOtherDisabledReasons(Object.values(actionDisabledReasonsRef.current));
+  }, [account, isProposalPassed, setOtherDisabledReasons, snapshotProposal]);
 
   /**
    * Functions

--- a/src/components/proposals/ProcessActionTribute.tsx
+++ b/src/components/proposals/ProcessActionTribute.tsx
@@ -1,0 +1,401 @@
+import {useState, useRef, useEffect, useCallback} from 'react';
+import {useSelector} from 'react-redux';
+import {toBN, AbiItem} from 'web3-utils';
+
+import {CycleEllipsis} from '../feedback';
+import {ProposalData, SnapshotProposal} from './types';
+import {StoreState} from '../../store/types';
+import {TX_CYCLE_MESSAGES} from '../web3/config';
+import {useContractSend, useETHGasPrice, useWeb3Modal} from '../web3/hooks';
+import {useMemberActionDisabled} from '../../hooks';
+import {Web3TxStatus} from '../web3/types';
+import CycleMessage from '../feedback/CycleMessage';
+import ErrorMessageWithDetails from '../common/ErrorMessageWithDetails';
+import EtherscanURL from '../web3/EtherscanURL';
+import FadeIn from '../common/FadeIn';
+import Loader from '../feedback/Loader';
+
+type ProcessArguments = [
+  string, // `dao`
+  string // `proposalId`
+];
+
+type TokenApproveArguments = [
+  string, // `spender`
+  string // `value`
+];
+
+type TributeProposalDetails = {
+  id: string;
+  applicant: string;
+  tokenToMint: string;
+  requestAmount: string;
+  token: string;
+  tributeAmount: string;
+  tributeTokenOwner: string;
+};
+
+type ProcessActionTributeProps = {
+  disabled?: boolean;
+  proposal: ProposalData;
+  isProposalPassed: boolean;
+};
+
+type ActionDisabledReasons = {
+  notProposerMessage: string;
+};
+
+/**
+ * Cached outside the component to prevent infinite re-renders.
+ *
+ * The same can be accomplished inside the component using
+ * `useState`, `useRef`, etc., depending on the use case.
+ */
+const useMemberActionDisabledProps = {
+  // Anyone can process a proposal - it's just a question of gas payment.
+  skipIsActiveMemberCheck: true,
+};
+
+export default function ProcessActionTribute(props: ProcessActionTributeProps) {
+  const {
+    disabled: propsDisabled,
+    proposal: {snapshotProposal},
+    isProposalPassed,
+  } = props;
+
+  /**
+   * State
+   */
+
+  const [submitError, setSubmitError] = useState<Error>();
+  const [
+    tributeProposalDetails,
+    setTributeProposalDetails,
+  ] = useState<TributeProposalDetails>();
+
+  /**
+   * Refs
+   */
+
+  const actionDisabledReasonsRef = useRef<ActionDisabledReasons>({
+    notProposerMessage: '',
+  });
+
+  /**
+   * Selectors
+   */
+
+  const TributeContract = useSelector(
+    (state: StoreState) => state.contracts?.TributeContract
+  );
+  const daoRegistryAddress = useSelector(
+    (s: StoreState) => s.contracts.DaoRegistryContract?.contractAddress
+  );
+
+  /**
+   * Our hooks
+   */
+
+  const {account, web3Instance} = useWeb3Modal();
+  const {txEtherscanURL, txIsPromptOpen, txSend, txStatus} = useContractSend();
+  const {
+    txEtherscanURL: txEtherscanURLTokenApprove,
+    txIsPromptOpen: txIsPromptOpenTokenApprove,
+    txSend: txSendTokenApprove,
+    txStatus: txStatusTokenApprove,
+  } = useContractSend();
+  const {
+    isDisabled,
+    openWhyDisabledModal,
+    WhyDisabledModal,
+    setOtherDisabledReasons,
+  } = useMemberActionDisabled(useMemberActionDisabledProps);
+  const gasPrices = useETHGasPrice();
+
+  /**
+   * Variables
+   */
+
+  const isInProcess =
+    txStatus === Web3TxStatus.AWAITING_CONFIRM ||
+    txStatus === Web3TxStatus.PENDING ||
+    txStatusTokenApprove === Web3TxStatus.AWAITING_CONFIRM ||
+    txStatusTokenApprove === Web3TxStatus.PENDING;
+  const isDone = txStatus === Web3TxStatus.FULFILLED;
+  const isInProcessOrDone =
+    isInProcess || isDone || txIsPromptOpen || txIsPromptOpenTokenApprove;
+  const areSomeDisabled = isDisabled || isInProcessOrDone || propsDisabled;
+
+  /**
+   * Cached callbacks
+   */
+
+  const getTributeProposalDetailsCached = useCallback(
+    getTributeProposalDetails,
+    [TributeContract, daoRegistryAddress, snapshotProposal]
+  );
+
+  /**
+   * Effects
+   */
+
+  useEffect(() => {
+    getTributeProposalDetailsCached();
+  }, [getTributeProposalDetailsCached]);
+
+  useEffect(() => {
+    // 1. Determine and set reasons why action would be disabled
+
+    // Reason: For some proposal types, a passed proposal can only be
+    // processed by its original proposer (e.g., the owner of the asset to be
+    // transferred)
+
+    // Proposals with this restriction will have this value stored in its
+    // snapshot metadata.
+    const {
+      accountAuthorizedToProcessPassedProposal,
+    } = (snapshotProposal as SnapshotProposal).msg.payload.metadata;
+
+    if (
+      isProposalPassed &&
+      accountAuthorizedToProcessPassedProposal &&
+      account
+    ) {
+      actionDisabledReasonsRef.current = {
+        ...actionDisabledReasonsRef.current,
+        notProposerMessage:
+          accountAuthorizedToProcessPassedProposal.toLowerCase() !==
+          account.toLowerCase()
+            ? 'Only the original proposer can process the proposal.'
+            : '',
+      };
+    }
+
+    // 2. Set reasons
+    setOtherDisabledReasons(Object.values(actionDisabledReasonsRef.current));
+  }, [account, isProposalPassed, setOtherDisabledReasons, snapshotProposal]);
+
+  /**
+   * Functions
+   */
+
+  async function getTributeProposalDetails() {
+    try {
+      if (!snapshotProposal || !TributeContract) return;
+
+      const proposalDetails = await TributeContract.instance.methods
+        .proposals(daoRegistryAddress, snapshotProposal.idInDAO)
+        .call();
+
+      setTributeProposalDetails(proposalDetails);
+    } catch (error) {
+      console.error(error);
+      setTributeProposalDetails(undefined);
+    }
+  }
+
+  async function handleSubmitTokenApprove() {
+    try {
+      if (!tributeProposalDetails) {
+        throw new Error('No Tribute proposal details found.');
+      }
+
+      if (!TributeContract) {
+        throw new Error('No TributeContract found.');
+      }
+
+      if (!account) {
+        throw new Error('No account found.');
+      }
+
+      const {token: tokenAddress, tributeAmount} = tributeProposalDetails;
+
+      const {default: lazyERC20ABI} = await import(
+        '../../truffle-contracts/ERC20.json'
+      );
+      const erc20Contract: AbiItem[] = lazyERC20ABI as any;
+      const erc20Instance = new web3Instance.eth.Contract(
+        erc20Contract,
+        tokenAddress
+      );
+
+      // Value to check if adapter is allowed to spend amount of tribute tokens
+      // on behalf of owner. If allowance is not sufficient, the owner will approve the adapter to spend the amount of
+      // tokens needed for the owner to provide the full tribute amount.
+      const allowance = await erc20Instance.methods
+        .allowance(account, TributeContract.contractAddress)
+        .call();
+
+      const tributeAmountBN = toBN(tributeAmount);
+      const allowanceBN = toBN(allowance);
+
+      if (tributeAmountBN.gt(allowanceBN)) {
+        try {
+          const difference = tributeAmountBN.sub(allowanceBN);
+          const approveValue = allowanceBN.add(difference);
+          const tokenApproveArguments: TokenApproveArguments = [
+            TributeContract.contractAddress,
+            approveValue.toString(),
+          ];
+          const txArguments = {
+            from: account || '',
+            // Set a fast gas price
+            ...(gasPrices ? {gasPrice: gasPrices.fast} : null),
+          };
+
+          // Execute contract call for `approve`
+          await txSendTokenApprove(
+            'approve',
+            erc20Instance.methods,
+            tokenApproveArguments,
+            txArguments
+          );
+        } catch (error) {
+          throw new Error(
+            'Your ERC20 tokens could not be approved for transfer.'
+          );
+        }
+      }
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  async function handleSubmit() {
+    try {
+      if (!daoRegistryAddress) {
+        throw new Error('No DAO Registry address was found.');
+      }
+
+      if (!snapshotProposal) {
+        throw new Error('No Snapshot proposal was found.');
+      }
+
+      if (!TributeContract) {
+        throw new Error('No TributeContract found.');
+      }
+
+      await handleSubmitTokenApprove();
+
+      const processArguments: ProcessArguments = [
+        daoRegistryAddress,
+        snapshotProposal.idInDAO,
+      ];
+
+      const txArguments = {
+        from: account || '',
+        // Set a fast gas price
+        ...(gasPrices ? {gasPrice: gasPrices.fast} : null),
+      };
+
+      await txSend(
+        'processProposal',
+        TributeContract.instance.methods,
+        processArguments,
+        txArguments
+      );
+    } catch (error) {
+      setSubmitError(error);
+    }
+  }
+
+  /**
+   * Render
+   */
+
+  function renderSubmitStatus(): React.ReactNode {
+    // token approve transaction statuses
+    if (txStatusTokenApprove === Web3TxStatus.AWAITING_CONFIRM) {
+      return (
+        <>
+          Confirm to transfer your tokens
+          <CycleEllipsis />
+        </>
+      );
+    }
+
+    if (txStatusTokenApprove === Web3TxStatus.PENDING) {
+      return (
+        <>
+          <div>
+            Approving your tokens for transfer
+            <CycleEllipsis />
+          </div>
+          <EtherscanURL url={txEtherscanURLTokenApprove} isPending />
+        </>
+      );
+    }
+
+    // process proposal transaction statuses
+    switch (txStatus) {
+      case Web3TxStatus.AWAITING_CONFIRM:
+        return (
+          <>
+            Confirm to process the proposal
+            <CycleEllipsis />
+          </>
+        );
+      case Web3TxStatus.PENDING:
+        return (
+          <>
+            <CycleMessage
+              intervalMs={2000}
+              messages={TX_CYCLE_MESSAGES}
+              useFirstItemStart
+              render={(message) => {
+                return <FadeIn key={message}>{message}</FadeIn>;
+              }}
+            />
+
+            <EtherscanURL url={txEtherscanURL} isPending />
+          </>
+        );
+      case Web3TxStatus.FULFILLED:
+        return (
+          <>
+            <div>Proposal submitted!</div>
+
+            <EtherscanURL url={txEtherscanURL} />
+          </>
+        );
+      default:
+        return null;
+    }
+  }
+
+  return (
+    <>
+      <div>
+        <button
+          className="proposaldetails__button"
+          disabled={areSomeDisabled}
+          onClick={areSomeDisabled ? () => {} : handleSubmit}>
+          {isInProcess ? <Loader /> : isDone ? 'Done' : 'Process'}
+        </button>
+
+        <ErrorMessageWithDetails
+          error={submitError}
+          renderText="Something went wrong"
+        />
+
+        {/* SUBMIT STATUS */}
+
+        {isInProcessOrDone && (
+          <div className="form__submit-status-container">
+            {renderSubmitStatus()}
+          </div>
+        )}
+
+        {isDisabled && (
+          <button
+            className="button--help-centered"
+            onClick={openWhyDisabledModal}>
+            Why is processing disabled?
+          </button>
+        )}
+      </div>
+
+      <WhyDisabledModal title="Why is processing disabled?" />
+    </>
+  );
+}

--- a/src/components/proposals/ProposalAmount.tsx
+++ b/src/components/proposals/ProposalAmount.tsx
@@ -1,7 +1,4 @@
 type ProposalAmountProps = {
-  /**
-   * Amount in WEI
-   */
   amount: string;
   amountUnit: string;
   amount2?: string;

--- a/src/components/proposals/ProposalWithOffchainVoteActions.tsx
+++ b/src/components/proposals/ProposalWithOffchainVoteActions.tsx
@@ -7,6 +7,7 @@ import {VotingState} from './voting/types';
 import {ContractAdapterNames} from '../web3/types';
 import {ProposalData, ProposalFlowStatus} from './types';
 import {useProposalWithOffchainVoteStatus} from './hooks';
+import SubmitAction from './SubmitAction';
 import SponsorAction from './SponsorAction';
 import ProcessAction from './ProcessAction';
 import PostProcessAction from './PostProcessAction';
@@ -67,6 +68,11 @@ export default function ProposalWithOffchainVoteActions(
       )}
 
       <div className="proposaldetails__button-container">
+        {/* SUBMIT/SPONSOR BUTTON (for proposals that have not been submitted onchain yet) */}
+        {status === ProposalFlowStatus.Submit && (
+          <SubmitAction proposal={proposal} />
+        )}
+
         {/* SPONSOR BUTTON */}
         {status === ProposalFlowStatus.Sponsor && (
           <SponsorAction proposal={proposal} />

--- a/src/components/proposals/ProposalWithOffchainVoteActions.tsx
+++ b/src/components/proposals/ProposalWithOffchainVoteActions.tsx
@@ -10,6 +10,7 @@ import {useProposalWithOffchainVoteStatus} from './hooks';
 import SubmitAction from './SubmitAction';
 import SponsorAction from './SponsorAction';
 import ProcessAction from './ProcessAction';
+import ProcessActionTribute from './ProcessActionTribute';
 import PostProcessAction from './PostProcessAction';
 
 type ProposalWithOffchainActionsProps = {
@@ -49,6 +50,38 @@ export default function ProposalWithOffchainVoteActions(
     status === ProposalFlowStatus.Completed &&
     daoProposalVoteResult &&
     VotingState[daoProposalVoteResult] === VotingState[VotingState.PASS];
+
+  /**
+   * Functions
+   */
+
+  function renderProcessAction() {
+    switch (adapterName) {
+      case ContractAdapterNames.tribute:
+        return (
+          <ProcessActionTribute
+            // Show during DAO proposal grace period, but set to disabled
+            disabled={status === ProposalFlowStatus.OffchainVotingGracePeriod}
+            proposal={proposal}
+            isProposalPassed={
+              !!(
+                daoProposalVoteResult &&
+                VotingState[daoProposalVoteResult] ===
+                  VotingState[VotingState.PASS]
+              )
+            }
+          />
+        );
+      default:
+        return (
+          <ProcessAction
+            // Show during DAO proposal grace period, but set to disabled
+            disabled={status === ProposalFlowStatus.OffchainVotingGracePeriod}
+            proposal={proposal}
+          />
+        );
+    }
+  }
 
   /**
    * Render
@@ -92,22 +125,12 @@ export default function ProposalWithOffchainVoteActions(
           />
         )}
 
+        {/* PROCESS BUTTON */}
         {(status === ProposalFlowStatus.OffchainVotingGracePeriod ||
-          status === ProposalFlowStatus.Process) && (
-          <ProcessAction
-            // Show during DAO proposal grace period, but set to disabled
-            disabled={status === ProposalFlowStatus.OffchainVotingGracePeriod}
-            proposal={proposal}
-            isProposalPassed={
-              !!(
-                daoProposalVoteResult &&
-                VotingState[daoProposalVoteResult] ===
-                  VotingState[VotingState.PASS]
-              )
-            }
-          />
-        )}
+          status === ProposalFlowStatus.Process) &&
+          renderProcessAction()}
 
+        {/* POST PROCESS BUTTON */}
         {showPostProcessAction && (
           <PostProcessAction adapterName={adapterName} proposal={proposal} />
         )}

--- a/src/components/proposals/ProposalWithOffchainVoteActions.tsx
+++ b/src/components/proposals/ProposalWithOffchainVoteActions.tsx
@@ -98,6 +98,13 @@ export default function ProposalWithOffchainVoteActions(
             // Show during DAO proposal grace period, but set to disabled
             disabled={status === ProposalFlowStatus.OffchainVotingGracePeriod}
             proposal={proposal}
+            isProposalPassed={
+              !!(
+                daoProposalVoteResult &&
+                VotingState[daoProposalVoteResult] ===
+                  VotingState[VotingState.PASS]
+              )
+            }
           />
         )}
 

--- a/src/components/proposals/Proposals.tsx
+++ b/src/components/proposals/Proposals.tsx
@@ -28,6 +28,11 @@ type ProposalsProps = {
    * Optionally render a custom proposal card.
    */
   renderProposalCard?: (data: {proposalData: ProposalData}) => React.ReactNode;
+  /**
+   * To handle proposal types where the first step is creating a snapshot
+   * draft/offchain proposal only (no onchain proposal exists)
+   */
+  includeProposalsExistingOnlyOffchain?: boolean;
 };
 
 type FilteredProposals = {
@@ -38,7 +43,12 @@ type FilteredProposals = {
 };
 
 export default function Proposals(props: ProposalsProps): JSX.Element {
-  const {adapterName, onProposalClick = () => {}, renderProposalCard} = props;
+  const {
+    adapterName,
+    onProposalClick = () => {},
+    renderProposalCard,
+    includeProposalsExistingOnlyOffchain = false,
+  } = props;
 
   /**
    * State
@@ -110,11 +120,12 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
         votesData?.OffchainVotingContract?.reporter === BURN_ADDRESS;
 
       // non-sponsored proposal
-      if (
-        voteState === undefined &&
-        proposalHasFlag(ProposalFlag.EXISTS, daoProposal.flags)
-      ) {
-        filteredProposalsToSet.nonsponsoredProposals.push(p);
+      if (voteState === undefined) {
+        if (includeProposalsExistingOnlyOffchain) {
+          filteredProposalsToSet.nonsponsoredProposals.push(p);
+        } else if (proposalHasFlag(ProposalFlag.EXISTS, daoProposal.flags)) {
+          filteredProposalsToSet.nonsponsoredProposals.push(p);
+        }
 
         return;
       }
@@ -162,7 +173,7 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
       ...prevState,
       ...filteredProposalsToSet,
     }));
-  }, [proposals, proposalsStatus]);
+  }, [includeProposalsExistingOnlyOffchain, proposals, proposalsStatus]);
 
   /**
    * Functions

--- a/src/components/proposals/Proposals.tsx
+++ b/src/components/proposals/Proposals.tsx
@@ -69,6 +69,7 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
 
   const {proposals, proposalsError, proposalsStatus} = useProposals({
     adapterName,
+    includeProposalsExistingOnlyOffchain,
   });
 
   /**

--- a/src/components/proposals/SponsorAction.tsx
+++ b/src/components/proposals/SponsorAction.tsx
@@ -159,6 +159,8 @@ export default function SponsorAction(props: SponsorActionProps) {
       };
 
       await txSend(
+        // @todo Remove the need for the custom function name when all the smart
+        // contracts are standardized with 'submitProposal'.
         metadata.sponsorActionFunctionName || 'sponsorProposal',
         contract.instance.methods,
         sponsorArguments,

--- a/src/components/proposals/SponsorAction.tsx
+++ b/src/components/proposals/SponsorAction.tsx
@@ -22,6 +22,7 @@ import Loader from '../feedback/Loader';
 type SponsorArguments = [
   string, // `dao`
   string, // `proposalId`
+  ...any[],
   string // `proposal data`
 ];
 
@@ -147,6 +148,7 @@ export default function SponsorAction(props: SponsorActionProps) {
       const sponsorArguments: SponsorArguments = [
         daoRegistryAddress,
         snapshotDraft.idInDAO,
+        ...(metadata.proposalArgs || []),
         preparedVoteVerificationBytes,
       ];
 
@@ -157,7 +159,7 @@ export default function SponsorAction(props: SponsorActionProps) {
       };
 
       await txSend(
-        'sponsorProposal',
+        metadata.sponsorActionFunctionName || 'sponsorProposal',
         contract.instance.methods,
         sponsorArguments,
         txArguments

--- a/src/components/proposals/SubmitAction.tsx
+++ b/src/components/proposals/SubmitAction.tsx
@@ -148,7 +148,7 @@ export default function SubmitAction(props: SubmitActionProps) {
       const submitArguments: SubmitArguments = [
         daoRegistryAddress,
         snapshotDraft.idInDAO,
-        ...(metadata.proposalArgs || []),
+        ...(metadata.submitActionArgs || []),
         preparedVoteVerificationBytes,
       ];
 

--- a/src/components/proposals/SubmitAction.tsx
+++ b/src/components/proposals/SubmitAction.tsx
@@ -19,17 +19,18 @@ import EtherscanURL from '../web3/EtherscanURL';
 import FadeIn from '../common/FadeIn';
 import Loader from '../feedback/Loader';
 
-type SponsorArguments = [
+type SubmitArguments = [
   string, // `dao`
   string, // `proposalId`
+  ...any[],
   string // `proposal data`
 ];
 
-type SponsorActionProps = {
+type SubmitActionProps = {
   proposal: ProposalData;
 };
 
-export default function SponsorAction(props: SponsorActionProps) {
+export default function SubmitAction(props: SubmitActionProps) {
   const {
     proposal: {snapshotDraft, refetchProposalOrDraft},
   } = props;
@@ -144,9 +145,10 @@ export default function SponsorAction(props: SponsorActionProps) {
         web3Instance
       );
 
-      const sponsorArguments: SponsorArguments = [
+      const submitArguments: SubmitArguments = [
         daoRegistryAddress,
         snapshotDraft.idInDAO,
+        ...(metadata.proposalArgs || []),
         preparedVoteVerificationBytes,
       ];
 
@@ -157,9 +159,9 @@ export default function SponsorAction(props: SponsorActionProps) {
       };
 
       await txSend(
-        'sponsorProposal',
+        'submitProposal',
         contract.instance.methods,
-        sponsorArguments,
+        submitArguments,
         txArguments
       );
 

--- a/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
+++ b/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
@@ -133,7 +133,7 @@ export function useProposalWithOffchainVoteStatus(
     offchainVotingABI,
     offchainVotingAddress,
     proposalId,
-    // snapshotDraft,
+    snapshotDraft,
     web3Instance,
   ]);
 

--- a/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
+++ b/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
@@ -133,6 +133,7 @@ export function useProposalWithOffchainVoteStatus(
     offchainVotingABI,
     offchainVotingAddress,
     proposalId,
+    // snapshotDraft,
     web3Instance,
   ]);
 
@@ -220,13 +221,19 @@ export function useProposalWithOffchainVoteStatus(
        * then only call the DAO for the proposal data and exit early.
        */
       if (!daoProposalVotingAdapter) {
-        const [proposal] = await multicall({
+        let [proposal] = await multicall({
           calls: [
             // DAO proposals call
             [daoRegistryAddress, proposalsABI, [proposalId]],
           ],
           web3Instance,
         });
+
+        // If proposal was not submitted onchain yet but there is snapshotDraft
+        // data then we set the initial daoProposal here.
+        if (proposal[0] === BURN_ADDRESS && snapshotDraft) {
+          proposal = {adapterAddress: snapshotDraft.actionId, flags: 1};
+        }
 
         setDAOProposal(proposal);
 

--- a/src/components/proposals/hooks/useProposals.ts
+++ b/src/components/proposals/hooks/useProposals.ts
@@ -34,12 +34,15 @@ type UseProposalsReturn = {
  * @todo Clean up noop functions in setting ProposalData - need a cleaner way to fulfill type.
  *
  * @param {string} adapterName Name of the adapter contract to get proposals for.
+ * @param {string} includeProposalsExistingOnlyOffchain To handle proposal types where the first step is creating a snapshot draft/offchain proposal only (no onchain proposal exists).
  * @returns `UseProposalsReturn` An object with the proposals, and the current async status.
  */
 export function useProposals({
   adapterName,
+  includeProposalsExistingOnlyOffchain = false,
 }: {
   adapterName: DaoAdapterConstants;
+  includeProposalsExistingOnlyOffchain?: boolean;
 }): UseProposalsReturn {
   /**
    * State
@@ -116,6 +119,7 @@ export function useProposals({
    */
 
   const getProposalsOnchainCached = useCallback(getProposalsOnchain, [
+    includeProposalsExistingOnlyOffchain,
     web3Instance,
   ]);
   const handleGetProposalsCached = useCallback(handleGetProposals, [
@@ -382,8 +386,12 @@ export function useProposals({
         proposals[i],
       ]);
 
-      // Filter-out proposals which do not exist
-      return entries.filter(([_, p]) => p.flags !== '0');
+      if (includeProposalsExistingOnlyOffchain) {
+        return entries;
+      } else {
+        // Filter-out proposals which do not exist
+        return entries.filter(([_, p]) => p.flags !== '0');
+      }
     } catch (error) {
       throw error;
     }

--- a/src/components/proposals/hooks/useProposals.ts
+++ b/src/components/proposals/hooks/useProposals.ts
@@ -118,13 +118,13 @@ export function useProposals({
    * Cached callbacks
    */
 
-  const getProposalsOnchainCached = useCallback(getProposalsOnchain, [
+  const getProposalsCached = useCallback(getProposals, [
     includeProposalsExistingOnlyOffchain,
     web3Instance,
   ]);
   const handleGetProposalsCached = useCallback(handleGetProposals, [
     adapterAddress,
-    getProposalsOnchainCached,
+    getProposalsCached,
     registryAbi,
     registryAddress,
   ]);
@@ -347,16 +347,18 @@ export function useProposals({
   }
 
   /**
-   * getProposalsOnchain
+   * getProposals
    *
-   * Gets on-chain proposals based on Snapshot Draft/Proposal ids,
-   * while filtering out proposals which were not found.
+   * Gets proposals based on Snapshot Draft/Proposal ids, while filtering out
+   * proposals which were not found onchain. Optional
+   * `includeProposalsExistingOnlyOffchain` flag can be set to also include
+   * draft proposals that exist only offchain.
    *
    * @note Should be called as a fallback to the subgraph failing.
    *
    * @returns `Promise<[string, Proposal][]` An array of tuples of [id, Proposal]
    */
-  async function getProposalsOnchain({
+  async function getProposals({
     proposalIds,
     registryAbi,
     registryAddress,
@@ -389,7 +391,7 @@ export function useProposals({
       if (includeProposalsExistingOnlyOffchain) {
         return entries;
       } else {
-        // Filter-out proposals which do not exist
+        // Filter-out proposals which do not exist onchain
         return entries.filter(([_, p]) => p.flags !== '0');
       }
     } catch (error) {
@@ -425,7 +427,7 @@ export function useProposals({
 
       // @todo `daoProposals`: swich/case depending on subgraph up/down
 
-      let daoProposals = await getProposalsOnchainCached({
+      let daoProposals = await getProposalsCached({
         proposalIds,
         registryAbi,
         registryAddress,

--- a/src/components/proposals/types.ts
+++ b/src/components/proposals/types.ts
@@ -33,6 +33,7 @@ export enum ProposalFlag {
 
 // @todo Need more information about the vote challenge flow.
 export enum ProposalFlowStatus {
+  Submit = 'Submit',
   Sponsor = 'Sponsor',
   OffchainVoting = 'OffchainVoting',
   OffchainVotingSubmitResult = 'OffchainVotingSubmitResult',

--- a/src/pages/membership/CreateMembershipProposal.tsx
+++ b/src/pages/membership/CreateMembershipProposal.tsx
@@ -2,13 +2,14 @@ import React, {useState, useCallback, useEffect} from 'react';
 import {SnapshotType} from '@openlaw/snapshot-js-erc712';
 import {useForm} from 'react-hook-form';
 import {useSelector} from 'react-redux';
-import Web3 from 'web3';
+import {toWei, toChecksumAddress} from 'web3-utils';
 
 import {
   getValidationError,
   stripFormatNumber,
   formatNumber,
   formatDecimal,
+  truncateEthAddress,
 } from '../../util/helpers';
 import {
   useContractSend,
@@ -188,11 +189,8 @@ export default function CreateMembershipProposal() {
       let proposalId: string = proposalData?.uniqueId || '';
 
       const {ethAddress, ethAmount} = values;
-      const ethAddressToChecksum = Web3.utils.toChecksumAddress(ethAddress);
-      const ethAmountInWei = Web3.utils.toWei(
-        stripFormatNumber(ethAmount),
-        'ether'
-      );
+      const ethAddressToChecksum = toChecksumAddress(ethAddress);
+      const ethAmountInWei = toWei(stripFormatNumber(ethAmount), 'ether');
 
       // Only submit to snapshot if there is not already a proposal ID returned from a previous attempt.
       if (!proposalId) {
@@ -200,7 +198,10 @@ export default function CreateMembershipProposal() {
         const {uniqueId} = await signAndSendProposal({
           partialProposalData: {
             name: ethAddressToChecksum,
-            body: `Membership for ${ethAddressToChecksum}.`,
+            body: `Membership for ${truncateEthAddress(
+              ethAddressToChecksum,
+              7
+            )}.`,
             metadata: {amountUnit: 'ETH'},
           },
           adapterName: ContractAdapterNames.onboarding,

--- a/src/pages/membership/CreateMembershipProposal.tsx
+++ b/src/pages/membership/CreateMembershipProposal.tsx
@@ -192,6 +192,15 @@ export default function CreateMembershipProposal() {
       const ethAddressToChecksum = toChecksumAddress(ethAddress);
       const ethAmountInWei = toWei(stripFormatNumber(ethAmount), 'ether');
 
+      // Values needed to display relevant proposal amounts in the proposal
+      // details page are set in the snapshot draft metadata. (We can no longer
+      // rely on getting this data from onchain because the proposal may not
+      // exist there yet.)
+      const proposalAmountValues = {
+        tributeAmount: ethAmount,
+        tributeAmountUnit: 'ETH',
+      };
+
       // Only submit to snapshot if there is not already a proposal ID returned from a previous attempt.
       if (!proposalId) {
         // Sign and submit draft for snapshot-hub
@@ -202,7 +211,7 @@ export default function CreateMembershipProposal() {
               ethAddressToChecksum,
               7
             )}.`,
-            metadata: {amountUnit: 'ETH'},
+            metadata: {proposalAmountValues},
           },
           adapterName: ContractAdapterNames.onboarding,
           type: SnapshotType.draft,

--- a/src/pages/membership/MembershipDetails.tsx
+++ b/src/pages/membership/MembershipDetails.tsx
@@ -13,6 +13,8 @@ import ProposalAmount from '../../components/proposals/ProposalAmount';
 import ProposalDetails from '../../components/proposals/ProposalDetails';
 import Wrap from '../../components/common/Wrap';
 
+const PLACEHOLDER = '\u2014'; /* em dash */
+
 export default function MembershipDetails() {
   /**
    * @todo
@@ -92,14 +94,17 @@ export default function MembershipDetails() {
   if (proposalData) {
     const commonData = proposalData.getCommonSnapshotProposalData();
 
-    let amount = '\u2026';
+    // Handle just in case metadata was not properly set
+    let tributeAmount = PLACEHOLDER;
+    let tributeAmountUnit = '';
     try {
-      // @todo Get amount from adapter's proposal's details if subgraph down: `proposals(...)`
-      // amount = formatDecimal(
-      //   Number(Web3.utils.fromWei(/* amount */ '', 'ether'))
-      // );
+      ({
+        tributeAmount,
+        tributeAmountUnit,
+      } = commonData?.msg.payload.metadata.proposalAmountValues);
     } catch (error) {
-      amount = '\u2026';
+      tributeAmount = PLACEHOLDER;
+      tributeAmountUnit = '';
     }
 
     return (
@@ -108,8 +113,8 @@ export default function MembershipDetails() {
           proposal={proposalData}
           renderAmountBadge={() => (
             <ProposalAmount
-              amount={amount}
-              amountUnit={commonData?.msg.payload.metadata.amountUnit}
+              amount={tributeAmount}
+              amountUnit={tributeAmountUnit}
             />
           )}
           renderActions={() => (

--- a/src/pages/transfers/CreateTransferProposal.tsx
+++ b/src/pages/transfers/CreateTransferProposal.tsx
@@ -15,6 +15,7 @@ import {
   stripFormatNumber,
   formatNumber,
   formatDecimal,
+  truncateEthAddress,
 } from '../../util/helpers';
 import {
   useContractSend,
@@ -94,7 +95,7 @@ export default function CreateTransferProposal() {
   );
 
   /**
-   * Hooks
+   * Our hooks
    */
 
   const {defaultChainError} = useIsDefaultChain();
@@ -107,7 +108,6 @@ export default function CreateTransferProposal() {
     txSend,
     txStatus,
   } = useContractSend();
-
   const {
     proposalData,
     proposalSignAndSendStatus,
@@ -395,7 +395,7 @@ export default function CreateTransferProposal() {
 
       const bodyIntro = isTypeAllMembers
         ? 'Transfer to all members pro rata.'
-        : `Transfer to ${memberAddressToChecksum}.`;
+        : `Transfer to ${truncateEthAddress(memberAddressToChecksum, 7)}.`;
 
       // Only submit to snapshot if there is not already a proposal ID returned from a previous attempt.
       if (!proposalId) {

--- a/src/pages/transfers/CreateTransferProposal.tsx
+++ b/src/pages/transfers/CreateTransferProposal.tsx
@@ -397,6 +397,15 @@ export default function CreateTransferProposal() {
         ? 'Transfer to all members pro rata.'
         : `Transfer to ${truncateEthAddress(memberAddressToChecksum, 7)}.`;
 
+      // Values needed to display relevant proposal amounts in the proposal
+      // details page are set in the snapshot draft metadata. (We can no longer
+      // rely on getting this data from onchain because the proposal may not
+      // exist there yet.)
+      const proposalAmountValues = {
+        transferAmount: amount,
+        transferAmountUnit: symbol,
+      };
+
       // Only submit to snapshot if there is not already a proposal ID returned from a previous attempt.
       if (!proposalId) {
         const body = notes ? `${bodyIntro}\n${notes}` : bodyIntro;
@@ -413,8 +422,7 @@ export default function CreateTransferProposal() {
             name,
             body,
             metadata: {
-              amountUnit: symbol,
-              tokenDecimals: decimals,
+              proposalAmountValues,
               isTypeAllMembers,
             },
             timestamp: now.toString(),

--- a/src/pages/transfers/TransferDetails.tsx
+++ b/src/pages/transfers/TransferDetails.tsx
@@ -13,6 +13,8 @@ import ProposalAmount from '../../components/proposals/ProposalAmount';
 import ProposalDetails from '../../components/proposals/ProposalDetails';
 import Wrap from '../../components/common/Wrap';
 
+const PLACEHOLDER = '\u2014'; /* em dash */
+
 export default function TransferDetails() {
   /**
    * @todo
@@ -92,24 +94,17 @@ export default function TransferDetails() {
   if (proposalData) {
     const commonData = proposalData.getCommonSnapshotProposalData();
 
-    let transferAmount = '\u2026';
-
+    // Handle just in case metadata was not properly set
+    let transferAmount = PLACEHOLDER;
+    let transferAmountUnit = '';
     try {
-      // @todo Get amount from adapter's proposal's details: `distributions(...)`
-      // const divisor = toBN(10).pow(
-      //   toBN(commonData?.msg.payload.metadata.tokenDecimals)
-      // );
-      // const beforeDecimal = toBN(/* amount */ '').div(divisor);
-      // const afterDecimal = toBN(/* amount */ '').mod(divisor);
-      // const balanceReadable = afterDecimal.eq(toBN(0))
-      //   ? beforeDecimal.toString()
-      //   : `${beforeDecimal.toString()}.${afterDecimal.toString()}`;
-      // const isTransferAmountInt = Number.isInteger(Number(balanceReadable));
-      // transferAmount = isTransferAmountInt
-      //   ? balanceReadable
-      //   : formatDecimal(Number(balanceReadable));
+      ({
+        transferAmount,
+        transferAmountUnit,
+      } = commonData?.msg.payload.metadata.proposalAmountValues);
     } catch (error) {
-      transferAmount = '\u2026';
+      transferAmount = PLACEHOLDER;
+      transferAmountUnit = '';
     }
 
     return (
@@ -119,7 +114,7 @@ export default function TransferDetails() {
           renderAmountBadge={() => (
             <ProposalAmount
               amount={transferAmount}
-              amountUnit={commonData?.msg.payload.metadata.amountUnit}
+              amountUnit={transferAmountUnit}
             />
           )}
           renderActions={() => (

--- a/src/pages/tributes/CreateTributeProposal.tsx
+++ b/src/pages/tributes/CreateTributeProposal.tsx
@@ -13,27 +13,21 @@ import {
   formatDecimal,
   normalizeString,
 } from '../../util/helpers';
-import {
-  useContractSend,
-  useETHGasPrice,
-  useIsDefaultChain,
-} from '../../components/web3/hooks';
+import {useIsDefaultChain} from '../../components/web3/hooks';
 import {ContractAdapterNames, Web3TxStatus} from '../../components/web3/types';
 import {FormFieldErrors} from '../../util/enums';
 import {isEthAddressValid} from '../../util/validation';
 import {truncateEthAddress} from '../../util/helpers';
 import {SHARES_ADDRESS} from '../../config';
 import {StoreState} from '../../store/types';
-import {TX_CYCLE_MESSAGES} from '../../components/web3/config';
 import {useSignAndSubmitProposal} from '../../components/proposals/hooks';
 import {useWeb3Modal} from '../../components/web3/hooks';
-import CycleMessage from '../../components/feedback/CycleMessage';
+import {CycleEllipsis} from '../../components/feedback';
 import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDetails';
 import FadeIn from '../../components/common/FadeIn';
 import InputError from '../../components/common/InputError';
 import Loader from '../../components/feedback/Loader';
 import Wrap from '../../components/common/Wrap';
-import EtherscanURL from '../../components/web3/EtherscanURL';
 
 enum Fields {
   applicantAddress = 'applicantAddress',
@@ -51,27 +45,19 @@ type FormInputs = {
   description: string;
 };
 
-type TributeArguments = [
-  string, // `dao`
-  string, // `proposalId`
+type ProposalArguments = [
   string, // `applicant`
   string, // `tokenToMint`
   string, // `requestAmount`
   string, // `tokenAddr`
-  string // `tributeAmount`
-];
-
-type TokenApproveArguments = [
-  string, // `spender`
-  string // `value`
+  string, // `tributeAmount`
+  string // `tributeTokenOwner`
 ];
 
 type ERC20Details = {
   symbol: string;
   decimals: number;
 };
-
-type BN = ReturnType<typeof toBN>;
 
 export default function CreateTributeProposal() {
   /**
@@ -91,24 +77,9 @@ export default function CreateTributeProposal() {
 
   const {defaultChainError} = useIsDefaultChain();
   const {connected, account, web3Instance} = useWeb3Modal();
-  const gasPrices = useETHGasPrice();
-  const {
-    txError,
-    txEtherscanURL,
-    txIsPromptOpen,
-    txSend,
-    txStatus,
-  } = useContractSend();
-  const {
-    txError: txErrorTokenApprove,
-    txEtherscanURL: txEtherscanURLTokenApprove,
-    txIsPromptOpen: txIsPromptOpenTokenApprove,
-    txSend: txSendTokenApprove,
-    txStatus: txStatusTokenApprove,
-  } = useContractSend();
-
   const {
     proposalData,
+    proposalSignAndSendError,
     proposalSignAndSendStatus,
     signAndSendProposal,
   } = useSignAndSubmitProposal<SnapshotType.draft>();
@@ -139,23 +110,16 @@ export default function CreateTributeProposal() {
   const {errors, getValues, setValue, register, trigger, watch} = form;
   const erc20AddressValue = watch('erc20Address');
 
-  const createTributeError = submitError || txError || txErrorTokenApprove;
+  const createTributeError = submitError || proposalSignAndSendError;
   const isConnected = connected && account;
 
   const isInProcess =
-    txStatus === Web3TxStatus.AWAITING_CONFIRM ||
-    txStatus === Web3TxStatus.PENDING ||
-    txStatusTokenApprove === Web3TxStatus.AWAITING_CONFIRM ||
-    txStatusTokenApprove === Web3TxStatus.PENDING ||
     proposalSignAndSendStatus === Web3TxStatus.AWAITING_CONFIRM ||
     proposalSignAndSendStatus === Web3TxStatus.PENDING;
 
-  const isDone =
-    txStatus === Web3TxStatus.FULFILLED &&
-    proposalSignAndSendStatus === Web3TxStatus.FULFILLED;
+  const isDone = proposalSignAndSendStatus === Web3TxStatus.FULFILLED;
 
-  const isInProcessOrDone =
-    isInProcess || isDone || txIsPromptOpen || txIsPromptOpenTokenApprove;
+  const isInProcessOrDone = isInProcess || isDone;
 
   /**
    * Cached callbacks
@@ -263,47 +227,6 @@ export default function CreateTributeProposal() {
     }
   }
 
-  async function handleSubmitTokenApprove(
-    tributeAmountWithDecimals: BN,
-    allowanceBN: BN
-  ) {
-    try {
-      if (!erc20Contract) {
-        throw new Error('No ERC20Contract found.');
-      }
-
-      if (!TributeContract) {
-        throw new Error('No TributeContract found.');
-      }
-
-      if (!account) {
-        throw new Error('No account found.');
-      }
-
-      const difference = tributeAmountWithDecimals.sub(allowanceBN);
-      const approveValue = allowanceBN.add(difference);
-      const tokenApproveArguments: TokenApproveArguments = [
-        TributeContract.contractAddress,
-        approveValue.toString(),
-      ];
-      const txArguments = {
-        from: account || '',
-        // Set a fast gas price
-        ...(gasPrices ? {gasPrice: gasPrices.fast} : null),
-      };
-
-      // Execute contract call for `approve`
-      await txSendTokenApprove(
-        'approve',
-        erc20Contract.methods,
-        tokenApproveArguments,
-        txArguments
-      );
-    } catch (error) {
-      throw error;
-    }
-  }
-
   async function handleSubmit(values: FormInputs) {
     try {
       if (!isConnected) {
@@ -346,29 +269,6 @@ export default function CreateTributeProposal() {
       const requestAmountArg = stripFormatNumber(requestAmount);
       const applicantAddressToChecksum = toChecksumAddress(applicantAddress);
 
-      // Check if adapter is allowed to spend amount of tribute tokens on behalf
-      // of user. If allowance is not sufficient, approve the adapter to spend
-      // the amount of tokens needed for the user to provide the full tribute
-      // amount.
-      const allowance = await erc20Contract.methods
-        .allowance(account, TributeContract.contractAddress)
-        .call();
-      const allowanceBN = toBN(allowance);
-
-      if (tributeAmountWithDecimals.gt(allowanceBN)) {
-        try {
-          await handleSubmitTokenApprove(
-            tributeAmountWithDecimals,
-            allowanceBN
-          );
-        } catch (error) {
-          console.error(error);
-          throw new Error(
-            'Your ERC20 tokens could not be approved for transfer.'
-          );
-        }
-      }
-
       // Maybe set proposal ID from previous attempt
       let proposalId: string = proposalData?.uniqueId || '';
 
@@ -376,7 +276,10 @@ export default function CreateTributeProposal() {
       if (!proposalId) {
         const bodyIntro =
           normalizeString(applicantAddress) === normalizeString(account)
-            ? `Tribute from ${applicantAddressToChecksum}.`
+            ? `Tribute from ${truncateEthAddress(
+                applicantAddressToChecksum,
+                7
+              )}.`
             : `Tribute from ${truncateEthAddress(
                 toChecksumAddress(account),
                 7
@@ -385,6 +288,15 @@ export default function CreateTributeProposal() {
                 7
               )}.`;
         const body = description ? `${bodyIntro}\n${description}` : bodyIntro;
+
+        const proposalArgs: ProposalArguments = [
+          applicantAddressToChecksum,
+          SHARES_ADDRESS,
+          requestAmountArg,
+          toChecksumAddress(erc20Address),
+          tributeAmountWithDecimals.toString(),
+          toChecksumAddress(account),
+        ];
 
         // Sign and submit draft for snapshot-hub
         const {uniqueId} = await signAndSendProposal({
@@ -395,6 +307,8 @@ export default function CreateTributeProposal() {
               tributeAmountUnit: erc20Details.symbol,
               tributeTokenDecimals: erc20Details.decimals,
               requestAmountUnit: 'SHARES',
+              proposalArgs,
+              sponsorActionFunctionName: 'submitProposal',
             },
           },
           adapterName: ContractAdapterNames.tribute,
@@ -403,30 +317,6 @@ export default function CreateTributeProposal() {
 
         proposalId = uniqueId;
       }
-
-      const tributeArguments: TributeArguments = [
-        DaoRegistryContract.contractAddress,
-        proposalId,
-        applicantAddressToChecksum,
-        SHARES_ADDRESS,
-        requestAmountArg,
-        erc20Address,
-        tributeAmountWithDecimals.toString(),
-      ];
-
-      const txArguments = {
-        from: account || '',
-        // Set a fast gas price
-        ...(gasPrices ? {gasPrice: gasPrices.fast} : null),
-      };
-
-      // Execute contract call for `provideTribute`
-      await txSend(
-        'provideTribute',
-        TributeContract.instance.methods,
-        tributeArguments,
-        txArguments
-      );
 
       // go to TributeDetails page for newly created tribute proposal
       history.push(`/tributes/${proposalId}`);
@@ -437,53 +327,25 @@ export default function CreateTributeProposal() {
   }
 
   function renderSubmitStatus(): React.ReactNode {
-    // Either Snapshot or chain tx
-    if (
-      txStatus === Web3TxStatus.AWAITING_CONFIRM ||
-      txStatusTokenApprove === Web3TxStatus.AWAITING_CONFIRM ||
-      proposalSignAndSendStatus === Web3TxStatus.AWAITING_CONFIRM
-    ) {
-      return 'Awaiting your confirmation\u2026';
-    }
-
-    // If token approve transaction is confirmed
-    if (txStatusTokenApprove === Web3TxStatus.PENDING) {
-      return (
-        <>
-          <div>{'Approving your tokens for transfer\u2026'}</div>
-
-          <EtherscanURL url={txEtherscanURLTokenApprove} isPending />
-        </>
-      );
-    }
-
-    // Only for chain tx
-    switch (txStatus) {
+    switch (proposalSignAndSendStatus) {
+      case Web3TxStatus.AWAITING_CONFIRM:
+        return (
+          <>
+            Awaiting your confirmation
+            <CycleEllipsis intervalMs={500} />
+          </>
+        );
       case Web3TxStatus.PENDING:
         return (
           <>
-            <CycleMessage
-              intervalMs={2000}
-              messages={TX_CYCLE_MESSAGES}
-              useFirstItemStart
-              render={(message) => {
-                return <FadeIn key={message}>{message}</FadeIn>;
-              }}
-            />
-
-            <EtherscanURL url={txEtherscanURL} isPending />
+            Submitting
+            <CycleEllipsis intervalMs={500} />
           </>
         );
       case Web3TxStatus.FULFILLED:
-        return (
-          <>
-            <div>Proposal submitted!</div>
-
-            <EtherscanURL url={txEtherscanURL} />
-          </>
-        );
+        return 'Done!';
       default:
-        return null;
+        return '';
     }
   }
 

--- a/src/pages/tributes/CreateTributeProposal.tsx
+++ b/src/pages/tributes/CreateTributeProposal.tsx
@@ -12,12 +12,12 @@ import {
   formatNumber,
   formatDecimal,
   normalizeString,
+  truncateEthAddress,
 } from '../../util/helpers';
 import {useIsDefaultChain} from '../../components/web3/hooks';
 import {ContractAdapterNames, Web3TxStatus} from '../../components/web3/types';
 import {FormFieldErrors} from '../../util/enums';
 import {isEthAddressValid} from '../../util/validation';
-import {truncateEthAddress} from '../../util/helpers';
 import {SHARES_ADDRESS} from '../../config';
 import {StoreState} from '../../store/types';
 import {useSignAndSubmitProposal} from '../../components/proposals/hooks';

--- a/src/pages/tributes/CreateTributeProposal.tsx
+++ b/src/pages/tributes/CreateTributeProposal.tsx
@@ -309,7 +309,6 @@ export default function CreateTributeProposal() {
               tributeTokenDecimals: erc20Details.decimals,
               requestAmountUnit: 'SHARES',
               proposalArgs,
-              sponsorActionFunctionName: 'submitProposal',
               accountAuthorizedToProcessPassedProposal: proposerAddressToChecksum,
             },
           },

--- a/src/pages/tributes/CreateTributeProposal.tsx
+++ b/src/pages/tributes/CreateTributeProposal.tsx
@@ -268,6 +268,7 @@ export default function CreateTributeProposal() {
       ).mul(multiplier);
       const requestAmountArg = stripFormatNumber(requestAmount);
       const applicantAddressToChecksum = toChecksumAddress(applicantAddress);
+      const proposerAddressToChecksum = toChecksumAddress(account);
 
       // Maybe set proposal ID from previous attempt
       let proposalId: string = proposalData?.uniqueId || '';
@@ -281,7 +282,7 @@ export default function CreateTributeProposal() {
                 7
               )}.`
             : `Tribute from ${truncateEthAddress(
-                toChecksumAddress(account),
+                proposerAddressToChecksum,
                 7
               )} for applicant ${truncateEthAddress(
                 applicantAddressToChecksum,
@@ -295,7 +296,7 @@ export default function CreateTributeProposal() {
           requestAmountArg,
           toChecksumAddress(erc20Address),
           tributeAmountWithDecimals.toString(),
-          toChecksumAddress(account),
+          proposerAddressToChecksum,
         ];
 
         // Sign and submit draft for snapshot-hub
@@ -309,6 +310,7 @@ export default function CreateTributeProposal() {
               requestAmountUnit: 'SHARES',
               proposalArgs,
               sponsorActionFunctionName: 'submitProposal',
+              accountAuthorizedToProcessPassedProposal: proposerAddressToChecksum,
             },
           },
           adapterName: ContractAdapterNames.tribute,

--- a/src/pages/tributes/CreateTributeProposal.tsx
+++ b/src/pages/tributes/CreateTributeProposal.tsx
@@ -45,7 +45,7 @@ type FormInputs = {
   description: string;
 };
 
-type ProposalArguments = [
+type SubmitActionArguments = [
   string, // `applicant`
   string, // `tokenToMint`
   string, // `requestAmount`
@@ -290,7 +290,20 @@ export default function CreateTributeProposal() {
               )}.`;
         const body = description ? `${bodyIntro}\n${description}` : bodyIntro;
 
-        const proposalArgs: ProposalArguments = [
+        // Values needed to display relevant proposal amounts in the proposal
+        // details page are set in the snapshot draft metadata. (We can no
+        // longer rely on getting this data from onchain because the proposal
+        // may not exist there yet.)
+        const proposalAmountValues = {
+          requestAmount,
+          requestAmountUnit: 'UNITS',
+          tributeAmount,
+          tributeAmountUnit: erc20Details.symbol,
+        };
+
+        // Arguments needed to submit the proposal onchain are set in the
+        // snapshot draft metadata.
+        const submitActionArgs: SubmitActionArguments = [
           applicantAddressToChecksum,
           SHARES_ADDRESS,
           requestAmountArg,
@@ -305,10 +318,8 @@ export default function CreateTributeProposal() {
             name: applicantAddressToChecksum,
             body,
             metadata: {
-              tributeAmountUnit: erc20Details.symbol,
-              tributeTokenDecimals: erc20Details.decimals,
-              requestAmountUnit: 'SHARES',
-              proposalArgs,
+              proposalAmountValues,
+              submitActionArgs,
               accountAuthorizedToProcessPassedProposal: proposerAddressToChecksum,
             },
           },

--- a/src/pages/tributes/TributeDetails.tsx
+++ b/src/pages/tributes/TributeDetails.tsx
@@ -3,7 +3,6 @@ import {useHistory, useParams} from 'react-router-dom';
 
 import {AsyncStatus} from '../../util/types';
 import {ContractAdapterNames} from '../../components/web3/types';
-import {formatNumber} from '../../util/helpers';
 import {useProposalOrDraft} from '../../components/proposals/hooks';
 import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDetails';
 import FadeIn from '../../components/common/FadeIn';
@@ -13,6 +12,9 @@ import ProposalActions from '../../components/proposals/ProposalActions';
 import ProposalAmount from '../../components/proposals/ProposalAmount';
 import ProposalDetails from '../../components/proposals/ProposalDetails';
 import Wrap from '../../components/common/Wrap';
+import {SnapshotProposalCommon} from '../../components/proposals/types';
+
+const PLACEHOLDER = '\u2026';
 
 export default function TributeDetails() {
   /**
@@ -92,32 +94,12 @@ export default function TributeDetails() {
   // Render proposal
   if (proposalData) {
     const commonData = proposalData.getCommonSnapshotProposalData();
-
-    let tributeAmount = '\u2026';
-    try {
-      // @todo Get amount from adapter's proposal's details if subgraph down: `proposals(...)`
-      // const divisor = toBN(10).pow(
-      //   toBN(commonData?.msg.payload.metadata.tributeTokenDecimals)
-      // );
-      // const beforeDecimal = toBN(/* tributeAmount */ '').div(divisor);
-      // const afterDecimal = toBN(/* tributeAmount */ '').mod(divisor);
-      // const balanceReadable = afterDecimal.eq(toBN(0))
-      //   ? beforeDecimal.toString()
-      //   : `${beforeDecimal.toString()}.${afterDecimal.toString()}`;
-      // const isTributeAmountInt = Number.isInteger(Number(balanceReadable));
-      // tributeAmount = isTributeAmountInt
-      //   ? balanceReadable
-      //   : formatDecimal(Number(balanceReadable));
-    } catch (error) {
-      tributeAmount = '\u2026';
-    }
-
-    let requestAmount = '\u2026';
-    try {
-      requestAmount = formatNumber(/* requestAmount */ '');
-    } catch (error) {
-      requestAmount = '\u2026';
-    }
+    const {
+      requestAmount,
+      requestAmountUnit,
+      tributeAmount,
+      tributeAmountUnit,
+    } = (commonData as SnapshotProposalCommon).msg.payload.metadata.proposalAmountValues;
 
     return (
       <RenderWrapper>
@@ -125,10 +107,10 @@ export default function TributeDetails() {
           proposal={proposalData}
           renderAmountBadge={() => (
             <ProposalAmount
-              amount={tributeAmount}
-              amountUnit={commonData?.msg.payload.metadata.tributeAmountUnit}
-              amount2={requestAmount}
-              amount2Unit={commonData?.msg.payload.metadata.requestAmountUnit}
+              amount={tributeAmount || PLACEHOLDER}
+              amountUnit={tributeAmountUnit || ''}
+              amount2={requestAmount || PLACEHOLDER}
+              amount2Unit={requestAmountUnit || ''}
             />
           )}
           renderActions={() => (

--- a/src/pages/tributes/TributeDetails.tsx
+++ b/src/pages/tributes/TributeDetails.tsx
@@ -12,9 +12,8 @@ import ProposalActions from '../../components/proposals/ProposalActions';
 import ProposalAmount from '../../components/proposals/ProposalAmount';
 import ProposalDetails from '../../components/proposals/ProposalDetails';
 import Wrap from '../../components/common/Wrap';
-import {SnapshotProposalCommon} from '../../components/proposals/types';
 
-const PLACEHOLDER = '\u2026';
+const PLACEHOLDER = '\u2014'; /* em dash */
 
 export default function TributeDetails() {
   /**
@@ -94,12 +93,25 @@ export default function TributeDetails() {
   // Render proposal
   if (proposalData) {
     const commonData = proposalData.getCommonSnapshotProposalData();
-    const {
-      requestAmount,
-      requestAmountUnit,
-      tributeAmount,
-      tributeAmountUnit,
-    } = (commonData as SnapshotProposalCommon).msg.payload.metadata.proposalAmountValues;
+
+    // Handle just in case metadata was not properly set
+    let tributeAmount = PLACEHOLDER;
+    let tributeAmountUnit = '';
+    let requestAmount = PLACEHOLDER;
+    let requestAmountUnit = '';
+    try {
+      ({
+        tributeAmount,
+        tributeAmountUnit,
+        requestAmount,
+        requestAmountUnit,
+      } = commonData?.msg.payload.metadata.proposalAmountValues);
+    } catch (error) {
+      tributeAmount = PLACEHOLDER;
+      tributeAmountUnit = '';
+      requestAmount = PLACEHOLDER;
+      requestAmountUnit = '';
+    }
 
     return (
       <RenderWrapper>
@@ -107,10 +119,10 @@ export default function TributeDetails() {
           proposal={proposalData}
           renderAmountBadge={() => (
             <ProposalAmount
-              amount={tributeAmount || PLACEHOLDER}
-              amountUnit={tributeAmountUnit || ''}
-              amount2={requestAmount || PLACEHOLDER}
-              amount2Unit={requestAmountUnit || ''}
+              amount={tributeAmount}
+              amountUnit={tributeAmountUnit}
+              amount2={requestAmount}
+              amount2Unit={requestAmountUnit}
             />
           )}
           renderActions={() => (

--- a/src/pages/tributes/Tributes.tsx
+++ b/src/pages/tributes/Tributes.tsx
@@ -30,6 +30,7 @@ export default function Tributes() {
       <Proposals
         adapterName={DaoAdapterConstants.TRIBUTE}
         onProposalClick={handleClickProposalDetails}
+        includeProposalsExistingOnlyOffchain={true}
       />
     </RenderWrapper>
   );

--- a/src/truffle-contracts/TributeContract.json
+++ b/src/truffle-contracts/TributeContract.json
@@ -1,24 +1,5 @@
 [
   {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "applicant",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "cause",
-        "type": "bytes32"
-      }
-    ],
-    "name": "FailedOnboarding",
-    "type": "event"
-  },
-  {
     "inputs": [
       {
         "internalType": "uint256",
@@ -112,11 +93,6 @@
       },
       {
         "internalType": "address",
-        "name": "proposer",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
         "name": "tokenToMint",
         "type": "address"
       },
@@ -134,6 +110,11 @@
         "internalType": "uint256",
         "name": "tributeAmount",
         "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "tributeTokenOwner",
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -171,39 +152,6 @@
   {
     "stateMutability": "payable",
     "type": "receive"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "contract DaoRegistry",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "provideTributeNFT",
-    "outputs": [],
-    "stateMutability": "pure",
-    "type": "function"
   },
   {
     "inputs": [
@@ -259,24 +207,11 @@
         "internalType": "uint256",
         "name": "tributeAmount",
         "type": "uint256"
-      }
-    ],
-    "name": "provideTribute",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "contract DaoRegistry",
-        "name": "dao",
-        "type": "address"
       },
       {
-        "internalType": "bytes32",
-        "name": "proposalId",
-        "type": "bytes32"
+        "internalType": "address",
+        "name": "tributeTokenOwner",
+        "type": "address"
       },
       {
         "internalType": "bytes",
@@ -284,25 +219,7 @@
         "type": "bytes"
       }
     ],
-    "name": "sponsorProposal",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "contract DaoRegistry",
-        "name": "dao",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "proposalId",
-        "type": "bytes32"
-      }
-    ],
-    "name": "cancelProposal",
+    "name": "submitProposal",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/src/truffle-contracts/TributeNFTContract.json
+++ b/src/truffle-contracts/TributeNFTContract.json
@@ -103,7 +103,7 @@
       },
       {
         "internalType": "uint256",
-        "name": "requestedShares",
+        "name": "requestAmount",
         "type": "uint256"
       }
     ],
@@ -160,49 +160,6 @@
     "inputs": [
       {
         "internalType": "contract DaoRegistry",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "provideTribute",
-    "outputs": [],
-    "stateMutability": "pure",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "contract DaoRegistry",
         "name": "dao",
         "type": "address"
       },
@@ -210,6 +167,11 @@
         "internalType": "bytes32",
         "name": "proposalId",
         "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "applicant",
+        "type": "address"
       },
       {
         "internalType": "address",
@@ -223,26 +185,8 @@
       },
       {
         "internalType": "uint256",
-        "name": "requestedShares",
+        "name": "requestAmount",
         "type": "uint256"
-      }
-    ],
-    "name": "provideTributeNFT",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "contract DaoRegistry",
-        "name": "dao",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "proposalId",
-        "type": "bytes32"
       },
       {
         "internalType": "bytes",
@@ -250,25 +194,7 @@
         "type": "bytes"
       }
     ],
-    "name": "sponsorProposal",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "contract DaoRegistry",
-        "name": "dao",
-        "type": "address"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "proposalId",
-        "type": "bytes32"
-      }
-    ],
-    "name": "cancelProposal",
+    "name": "submitProposal",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -289,40 +215,6 @@
     "name": "processProposal",
     "outputs": [],
     "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      },
-      {
-        "internalType": "bytes",
-        "name": "",
-        "type": "bytes"
-      }
-    ],
-    "name": "onERC721Received",
-    "outputs": [
-      {
-        "internalType": "bytes4",
-        "name": "",
-        "type": "bytes4"
-      }
-    ],
-    "stateMutability": "pure",
     "type": "function"
   }
 ]


### PR DESCRIPTION
Frontend updates required to handle recent smart contract updates in openlawteam/molochv3-contracts#265. The `Tribute` adapter now works e2e to handle the following flow:
1. Draft snapshot proposal submitted (offchain only).
2. Member submits and sponsors proposal onchain.
3. Members vote on proposal.
3. If proposal passes, only the original proposer can process it. When the passed proposal is processed, the user handles both the transaction required to approve the token transfer and the transaction to process the proposal.
4. If the proposal failed, anyone can process it.

🥳 **Adds**

 - `ProcessActionTribute.tsx` (For now the easiest way to handle the complex process actions with multiple transactions for an adapter is to have its own component).
 - `SubmitAction.tsx` to handle new action of the proposal being submitted onchain.
 - `proposalAmountValues` to proposal metadata on submission so we can render the amount badges (we can't rely on onchain data because the proposal may not exist there yet).
 - `submitActionArgs` to proposal metadata on submission for the new type of proposal that is initially created as an offchain draft only. We need those args set so we can later use them to make the onchain proposal submission.

✨ **Updates**

 - Various updates to handle the new flow as described above.
 - Proposal amount badges now show the correct amounts and units.
 - `TributeContract` and `TributeNFTContract` ABI files.
 
@jtrein @sophiacodes There are breaking changes here so you should start with fresh snapshot and subgraph data when running locally. The development site will be broken for now until we deploy new contracts for it.