### PR TITLE
Render adapter-specific actions in render prop

### DIFF
--- a/src/components/proposals/PostProcessActionTransfer.tsx
+++ b/src/components/proposals/PostProcessActionTransfer.tsx
@@ -2,40 +2,35 @@ import React, {useEffect, useState, useRef} from 'react';
 import {useSelector} from 'react-redux';
 
 import {CycleEllipsis} from '../feedback';
-import {getContractByAddress} from '../web3/helpers';
 import {ProposalData, DistributionStatus} from './types';
 import {StoreState} from '../../store/types';
 import {TX_CYCLE_MESSAGES} from '../web3/config';
 import {useContractSend, useETHGasPrice, useWeb3Modal} from '../web3/hooks';
 import {useMemberActionDisabled} from '../../hooks';
-import {ContractAdapterNames, Web3TxStatus} from '../web3/types';
+import {Web3TxStatus} from '../web3/types';
 import CycleMessage from '../feedback/CycleMessage';
 import ErrorMessageWithDetails from '../common/ErrorMessageWithDetails';
 import EtherscanURL from '../web3/EtherscanURL';
 import FadeIn from '../common/FadeIn';
 import Loader from '../feedback/Loader';
 
-type ProcessActionProps = {
-  adapterName: ContractAdapterNames;
-  proposal: ProposalData;
-};
+type DistributeArguments = [
+  string, // `dao`
+  string // `toIndex`
+];
 
-type SubmitConfigs = {
-  functionName: string;
-  functionArguments: any[];
+type PostProcessActionTransferProps = {
+  proposal: ProposalData;
 };
 
 type ActionDisabledReasons = {
   alreadyCompletedMessage: string;
 };
 
-/**
- * @note Attempt to keep this component general to handle any adapters that may
- * have post-process actions
- */
-export default function PostProcessAction(props: ProcessActionProps) {
+export default function PostProcessActionTransfer(
+  props: PostProcessActionTransferProps
+) {
   const {
-    adapterName,
     proposal: {snapshotProposal},
   } = props;
 
@@ -57,7 +52,9 @@ export default function PostProcessAction(props: ProcessActionProps) {
    * Selectors
    */
 
-  const contracts = useSelector((s: StoreState) => s.contracts);
+  const DistributeContract = useSelector(
+    (state: StoreState) => state.contracts?.DistributeContract
+  );
   const daoRegistryContract = useSelector(
     (s: StoreState) => s.contracts.DaoRegistryContract
   );
@@ -67,16 +64,13 @@ export default function PostProcessAction(props: ProcessActionProps) {
    */
 
   const {account} = useWeb3Modal();
-
   const {txEtherscanURL, txIsPromptOpen, txSend, txStatus} = useContractSend();
-
   const {
     isDisabled,
     openWhyDisabledModal,
     WhyDisabledModal,
     setOtherDisabledReasons,
   } = useMemberActionDisabled();
-
   const gasPrices = useETHGasPrice();
 
   /**
@@ -86,7 +80,6 @@ export default function PostProcessAction(props: ProcessActionProps) {
   const isInProcess =
     txStatus === Web3TxStatus.AWAITING_CONFIRM ||
     txStatus === Web3TxStatus.PENDING;
-
   const isDone = txStatus === Web3TxStatus.FULFILLED;
   const isInProcessOrDone = isInProcess || isDone || txIsPromptOpen;
   const areSomeDisabled = isDisabled || isInProcessOrDone;
@@ -100,37 +93,34 @@ export default function PostProcessAction(props: ProcessActionProps) {
       // 1. Determine and set reasons why action would be disabled
 
       // Reason: distribution already completed
-      if (adapterName === ContractAdapterNames.distribute) {
+      try {
         if (!snapshotProposal) {
           throw new Error('No Snapshot proposal was found.');
         }
         if (!daoRegistryContract) {
           throw new Error('No DAO Registry contract was found.');
         }
-
-        try {
-          const distributeContract = getContractByAddress(
-            snapshotProposal.actionId,
-            contracts
-          );
-          const distributeProposal = await distributeContract.instance.methods
-            .distributions(
-              daoRegistryContract.contractAddress,
-              snapshotProposal.idInDAO
-            )
-            .call();
-
-          actionDisabledReasonsRef.current = {
-            ...actionDisabledReasonsRef.current,
-            alreadyCompletedMessage:
-              DistributionStatus[distributeProposal.status] !==
-              DistributionStatus[DistributionStatus.IN_PROGRESS]
-                ? 'The transfer has already been completed.'
-                : '',
-          };
-        } catch (error) {
-          console.error(error);
+        if (!DistributeContract) {
+          throw new Error('No DistributeContract found.');
         }
+
+        const distributeProposal = await DistributeContract.instance.methods
+          .distributions(
+            daoRegistryContract.contractAddress,
+            snapshotProposal.idInDAO
+          )
+          .call();
+
+        actionDisabledReasonsRef.current = {
+          ...actionDisabledReasonsRef.current,
+          alreadyCompletedMessage:
+            DistributionStatus[distributeProposal.status] !==
+            DistributionStatus[DistributionStatus.IN_PROGRESS]
+              ? 'The transfer has already been completed.'
+              : '',
+        };
+      } catch (error) {
+        console.error(error);
       }
 
       // 2. Set reasons
@@ -139,8 +129,7 @@ export default function PostProcessAction(props: ProcessActionProps) {
 
     getActionDisabledReasons();
   }, [
-    adapterName,
-    contracts,
+    DistributeContract,
     daoRegistryContract,
     setOtherDisabledReasons,
     snapshotProposal,
@@ -150,51 +139,38 @@ export default function PostProcessAction(props: ProcessActionProps) {
    * Functions
    */
 
-  async function getSubmitConfigsByAdapter(): Promise<SubmitConfigs> {
-    switch (adapterName) {
-      case ContractAdapterNames.distribute:
-        if (!daoRegistryContract) {
-          throw new Error('No DAO Registry contract was found.');
-        }
-
-        let toIndexArg = '0';
-        const isTypeAllMembers =
-          snapshotProposal?.msg.payload.metadata.isTypeAllMembers;
-        if (isTypeAllMembers) {
-          try {
-            const nbMembers = await daoRegistryContract.instance.methods
-              .getNbMembers()
-              .call();
-            toIndexArg = nbMembers.toString();
-          } catch (error) {
-            throw new Error('Error while retrieving number of DAO members');
-          }
-        }
-
-        return {
-          functionName: 'distribute',
-          functionArguments: [daoRegistryContract.contractAddress, toIndexArg],
-        };
-      default:
-        return {functionName: '', functionArguments: []};
-    }
-  }
-
   async function handleSubmit() {
     try {
+      if (!daoRegistryContract) {
+        throw new Error('No DAO Registry contract was found.');
+      }
+
       if (!snapshotProposal) {
         throw new Error('No Snapshot proposal was found.');
       }
 
-      const contract = getContractByAddress(
-        snapshotProposal.actionId,
-        contracts
-      );
+      if (!DistributeContract) {
+        throw new Error('No DistributeContract found.');
+      }
 
-      const {
-        functionName,
-        functionArguments,
-      } = await getSubmitConfigsByAdapter();
+      let toIndexArg = '0';
+      const isTypeAllMembers =
+        snapshotProposal?.msg.payload.metadata.isTypeAllMembers;
+      if (isTypeAllMembers) {
+        try {
+          const nbMembers = await daoRegistryContract.instance.methods
+            .getNbMembers()
+            .call();
+          toIndexArg = nbMembers.toString();
+        } catch (error) {
+          throw new Error('Error while retrieving number of DAO members');
+        }
+      }
+
+      const distributeArguments: DistributeArguments = [
+        daoRegistryContract.contractAddress,
+        toIndexArg,
+      ];
 
       const txArguments = {
         from: account || '',
@@ -203,9 +179,9 @@ export default function PostProcessAction(props: ProcessActionProps) {
       };
 
       await txSend(
-        functionName,
-        contract.instance.methods,
-        functionArguments,
+        'distribute',
+        DistributeContract.instance.methods,
+        distributeArguments,
         txArguments
       );
     } catch (error) {
@@ -217,31 +193,13 @@ export default function PostProcessAction(props: ProcessActionProps) {
    * Render
    */
 
-  function renderSubmitStatusByAdapter(): string {
-    switch (adapterName) {
-      case ContractAdapterNames.distribute:
-        return 'Assets transferred!';
-      default:
-        return 'Action submitted!';
-    }
-  }
-
-  function renderButtonTextByAdapter(): {start: string; done: string} {
-    switch (adapterName) {
-      case ContractAdapterNames.distribute:
-        return {start: 'Transfer assets', done: 'Transfer done'};
-      default:
-        return {start: 'Process action', done: 'Done'};
-    }
-  }
-
   function renderSubmitStatus(): React.ReactNode {
-    // Only for chain tx
+    // distribute transaction statuses
     switch (txStatus) {
       case Web3TxStatus.AWAITING_CONFIRM:
         return (
           <>
-            Awaiting your confirmation
+            Confirm to transfer assets
             <CycleEllipsis />
           </>
         );
@@ -263,7 +221,7 @@ export default function PostProcessAction(props: ProcessActionProps) {
       case Web3TxStatus.FULFILLED:
         return (
           <>
-            <div>{renderSubmitStatusByAdapter()}</div>
+            <div>Assets transferred!</div>
 
             <EtherscanURL url={txEtherscanURL} />
           </>
@@ -283,9 +241,9 @@ export default function PostProcessAction(props: ProcessActionProps) {
           {isInProcess ? (
             <Loader />
           ) : isDone ? (
-            renderButtonTextByAdapter()['done']
+            'Transfer done'
           ) : (
-            renderButtonTextByAdapter()['start']
+            'Transfer assets'
           )}
         </button>
 
@@ -311,7 +269,7 @@ export default function PostProcessAction(props: ProcessActionProps) {
         )}
       </div>
 
-      <WhyDisabledModal title="Why is action disabled?" />
+      <WhyDisabledModal title="Why is transfer disabled?" />
     </>
   );
 }

--- a/src/components/proposals/ProcessActionMembership.tsx
+++ b/src/components/proposals/ProcessActionMembership.tsx
@@ -22,7 +22,6 @@ type ProcessArguments = [
 type ProcessActionMembershipProps = {
   disabled?: boolean;
   proposal: ProposalData;
-  isProposalPassed: boolean;
 };
 
 type ActionDisabledReasons = {
@@ -46,7 +45,6 @@ export default function ProcessActionMembership(
   const {
     disabled: propsDisabled,
     proposal: {snapshotProposal},
-    isProposalPassed,
   } = props;
 
   /**
@@ -117,40 +115,36 @@ export default function ProcessActionMembership(
    */
 
   useEffect(() => {
-    if (isProposalPassed) {
-      getMembershipProposalAmountCached();
-    }
-  }, [getMembershipProposalAmountCached, isProposalPassed]);
+    getMembershipProposalAmountCached();
+  }, [getMembershipProposalAmountCached]);
 
   useEffect(() => {
-    if (isProposalPassed) {
-      // 1. Determine and set reasons why action would be disabled
+    // 1. Determine and set reasons why action would be disabled
 
-      // Reason: For some proposal types, a passed proposal can only be
-      // processed by its original proposer (e.g., the owner of the asset to be
-      // transferred)
+    // Reason: For some proposal types, a passed proposal can only be
+    // processed by its original proposer (e.g., the owner of the asset to be
+    // transferred)
 
-      // Proposals with this restriction will have this value stored in its
-      // snapshot metadata.
-      const {
-        accountAuthorizedToProcessPassedProposal,
-      } = (snapshotProposal as SnapshotProposal).msg.payload.metadata;
+    // Proposals with this restriction will have this value stored in its
+    // snapshot metadata.
+    const {
+      accountAuthorizedToProcessPassedProposal,
+    } = (snapshotProposal as SnapshotProposal).msg.payload.metadata;
 
-      if (accountAuthorizedToProcessPassedProposal && account) {
-        actionDisabledReasonsRef.current = {
-          ...actionDisabledReasonsRef.current,
-          notProposerMessage:
-            accountAuthorizedToProcessPassedProposal.toLowerCase() !==
-            account.toLowerCase()
-              ? 'Only the original proposer can process the proposal.'
-              : '',
-        };
-      }
-
-      // 2. Set reasons
-      setOtherDisabledReasons(Object.values(actionDisabledReasonsRef.current));
+    if (accountAuthorizedToProcessPassedProposal && account) {
+      actionDisabledReasonsRef.current = {
+        ...actionDisabledReasonsRef.current,
+        notProposerMessage:
+          accountAuthorizedToProcessPassedProposal.toLowerCase() !==
+          account.toLowerCase()
+            ? 'Only the original proposer can process the proposal.'
+            : '',
+      };
     }
-  }, [account, isProposalPassed, setOtherDisabledReasons, snapshotProposal]);
+
+    // 2. Set reasons
+    setOtherDisabledReasons(Object.values(actionDisabledReasonsRef.current));
+  }, [account, setOtherDisabledReasons, snapshotProposal]);
 
   /**
    * Functions
@@ -252,45 +246,37 @@ export default function ProcessActionMembership(
 
   return (
     <>
-      {isProposalPassed ? (
-        <>
-          <div>
-            <button
-              className="proposaldetails__button"
-              disabled={areSomeDisabled}
-              onClick={areSomeDisabled ? () => {} : handleSubmit}>
-              {isInProcess ? <Loader /> : isDone ? 'Done' : 'Process'}
-            </button>
+      <div>
+        <button
+          className="proposaldetails__button"
+          disabled={areSomeDisabled}
+          onClick={areSomeDisabled ? () => {} : handleSubmit}>
+          {isInProcess ? <Loader /> : isDone ? 'Done' : 'Process'}
+        </button>
 
-            <ErrorMessageWithDetails
-              error={submitError}
-              renderText="Something went wrong"
-            />
+        <ErrorMessageWithDetails
+          error={submitError}
+          renderText="Something went wrong"
+        />
 
-            {/* SUBMIT STATUS */}
+        {/* SUBMIT STATUS */}
 
-            {isInProcessOrDone && (
-              <div className="form__submit-status-container">
-                {renderSubmitStatus()}
-              </div>
-            )}
-
-            {isDisabled && (
-              <button
-                className="button--help-centered"
-                onClick={openWhyDisabledModal}>
-                Why is processing disabled?
-              </button>
-            )}
+        {isInProcessOrDone && (
+          <div className="form__submit-status-container">
+            {renderSubmitStatus()}
           </div>
+        )}
 
-          <WhyDisabledModal title="Why is processing disabled?" />
-        </>
-      ) : (
-        // If proposal failed there is no reason to process it. So just show
-        // nothing.
-        <></>
-      )}
+        {isDisabled && (
+          <button
+            className="button--help-centered"
+            onClick={openWhyDisabledModal}>
+            Why is processing disabled?
+          </button>
+        )}
+      </div>
+
+      <WhyDisabledModal title="Why is processing disabled?" />
     </>
   );
 }

--- a/src/components/proposals/ProcessActionTribute.tsx
+++ b/src/components/proposals/ProcessActionTribute.tsx
@@ -33,7 +33,6 @@ type TributeProposalDetails = {
 type ProcessActionTributeProps = {
   disabled?: boolean;
   proposal: ProposalData;
-  isProposalPassed: boolean;
 };
 
 type ActionDisabledReasons = {
@@ -55,7 +54,6 @@ export default function ProcessActionTribute(props: ProcessActionTributeProps) {
   const {
     disabled: propsDisabled,
     proposal: {snapshotProposal},
-    isProposalPassed,
   } = props;
 
   /**
@@ -135,40 +133,36 @@ export default function ProcessActionTribute(props: ProcessActionTributeProps) {
    */
 
   useEffect(() => {
-    if (isProposalPassed) {
-      getTributeProposalDetailsCached();
-    }
-  }, [getTributeProposalDetailsCached, isProposalPassed]);
+    getTributeProposalDetailsCached();
+  }, [getTributeProposalDetailsCached]);
 
   useEffect(() => {
-    if (isProposalPassed) {
-      // 1. Determine and set reasons why action would be disabled
+    // 1. Determine and set reasons why action would be disabled
 
-      // Reason: For some proposal types, a passed proposal can only be
-      // processed by its original proposer (e.g., the owner of the asset to be
-      // transferred)
+    // Reason: For some proposal types, a passed proposal can only be
+    // processed by its original proposer (e.g., the owner of the asset to be
+    // transferred)
 
-      // Proposals with this restriction will have this value stored in its
-      // snapshot metadata.
-      const {
-        accountAuthorizedToProcessPassedProposal,
-      } = (snapshotProposal as SnapshotProposal).msg.payload.metadata;
+    // Proposals with this restriction will have this value stored in its
+    // snapshot metadata.
+    const {
+      accountAuthorizedToProcessPassedProposal,
+    } = (snapshotProposal as SnapshotProposal).msg.payload.metadata;
 
-      if (accountAuthorizedToProcessPassedProposal && account) {
-        actionDisabledReasonsRef.current = {
-          ...actionDisabledReasonsRef.current,
-          notProposerMessage:
-            accountAuthorizedToProcessPassedProposal.toLowerCase() !==
-            account.toLowerCase()
-              ? 'Only the original proposer can process the proposal.'
-              : '',
-        };
-      }
-
-      // 2. Set reasons
-      setOtherDisabledReasons(Object.values(actionDisabledReasonsRef.current));
+    if (accountAuthorizedToProcessPassedProposal && account) {
+      actionDisabledReasonsRef.current = {
+        ...actionDisabledReasonsRef.current,
+        notProposerMessage:
+          accountAuthorizedToProcessPassedProposal.toLowerCase() !==
+          account.toLowerCase()
+            ? 'Only the original proposer can process the proposal.'
+            : '',
+      };
     }
-  }, [account, isProposalPassed, setOtherDisabledReasons, snapshotProposal]);
+
+    // 2. Set reasons
+    setOtherDisabledReasons(Object.values(actionDisabledReasonsRef.current));
+  }, [account, setOtherDisabledReasons, snapshotProposal]);
 
   /**
    * Functions
@@ -361,45 +355,37 @@ export default function ProcessActionTribute(props: ProcessActionTributeProps) {
 
   return (
     <>
-      {isProposalPassed ? (
-        <>
-          <div>
-            <button
-              className="proposaldetails__button"
-              disabled={areSomeDisabled}
-              onClick={areSomeDisabled ? () => {} : handleSubmit}>
-              {isInProcess ? <Loader /> : isDone ? 'Done' : 'Process'}
-            </button>
+      <div>
+        <button
+          className="proposaldetails__button"
+          disabled={areSomeDisabled}
+          onClick={areSomeDisabled ? () => {} : handleSubmit}>
+          {isInProcess ? <Loader /> : isDone ? 'Done' : 'Process'}
+        </button>
 
-            <ErrorMessageWithDetails
-              error={submitError}
-              renderText="Something went wrong"
-            />
+        <ErrorMessageWithDetails
+          error={submitError}
+          renderText="Something went wrong"
+        />
 
-            {/* SUBMIT STATUS */}
+        {/* SUBMIT STATUS */}
 
-            {isInProcessOrDone && (
-              <div className="form__submit-status-container">
-                {renderSubmitStatus()}
-              </div>
-            )}
-
-            {isDisabled && (
-              <button
-                className="button--help-centered"
-                onClick={openWhyDisabledModal}>
-                Why is processing disabled?
-              </button>
-            )}
+        {isInProcessOrDone && (
+          <div className="form__submit-status-container">
+            {renderSubmitStatus()}
           </div>
+        )}
 
-          <WhyDisabledModal title="Why is processing disabled?" />
-        </>
-      ) : (
-        // If proposal failed there is no reason to process it. So just show
-        // nothing.
-        <></>
-      )}
+        {isDisabled && (
+          <button
+            className="button--help-centered"
+            onClick={openWhyDisabledModal}>
+            Why is processing disabled?
+          </button>
+        )}
+      </div>
+
+      <WhyDisabledModal title="Why is processing disabled?" />
     </>
   );
 }

--- a/src/components/proposals/ProposalWithOffchainVoteActions.tsx
+++ b/src/components/proposals/ProposalWithOffchainVoteActions.tsx
@@ -88,34 +88,6 @@ export default function ProposalWithOffchainVoteActions(
    * Functions
    */
 
-  function renderProcessAction() {
-    switch (adapterName) {
-      case ContractAdapterNames.tribute:
-        return (
-          <ProcessActionTribute
-            // Show during DAO proposal grace period, but set to disabled
-            disabled={status === ProposalFlowStatus.OffchainVotingGracePeriod}
-            proposal={proposal}
-            isProposalPassed={
-              !!(
-                daoProposalVoteResult &&
-                VotingState[daoProposalVoteResult] ===
-                  VotingState[VotingState.PASS]
-              )
-            }
-          />
-        );
-      default:
-        return (
-          <ProcessAction
-            // Show during DAO proposal grace period, but set to disabled
-            disabled={status === ProposalFlowStatus.OffchainVotingGracePeriod}
-            proposal={proposal}
-          />
-        );
-    }
-  }
-
   function renderActions(): React.ReactNode {
     // If render prop did not return `null` then render its content
     if (renderedActionFromProp) {
@@ -150,12 +122,17 @@ export default function ProposalWithOffchainVoteActions(
     }
 
     // Process button
-    // @todo Remove and use render prop
     if (
       status === ProposalFlowStatus.Process ||
       status === ProposalFlowStatus.OffchainVotingGracePeriod
     ) {
-      return renderProcessAction();
+      return (
+        <ProcessAction
+          // Show during DAO proposal grace period, but set to disabled
+          disabled={status === ProposalFlowStatus.OffchainVotingGracePeriod}
+          proposal={proposal}
+        />
+      );
     }
 
     // Post-process button

--- a/src/components/proposals/ProposalWithOffchainVoteActions.tsx
+++ b/src/components/proposals/ProposalWithOffchainVoteActions.tsx
@@ -11,11 +11,8 @@ import {
 import {ContractAdapterNames} from '../web3/types';
 import {useProposalWithOffchainVoteStatus} from './hooks';
 import {VotingAdapterName} from '../adapters-extensions/enums';
-import {VotingState} from './voting/types';
 import ErrorMessageWithDetails from '../common/ErrorMessageWithDetails';
-import PostProcessAction from './PostProcessAction';
 import ProcessAction from './ProcessAction';
-import ProcessActionTribute from './ProcessActionTribute';
 import SponsorAction from './SponsorAction';
 import SubmitAction from './SubmitAction';
 
@@ -58,14 +55,6 @@ export default function ProposalWithOffchainVoteActions(
     daoProposalVotes && status === ProposalFlowStatus.OffchainVotingGracePeriod
       ? Number(daoProposalVotes.gracePeriodStartingTime) * 1000
       : 0;
-
-  //  Currently, only Distribute adapter has an action that occurs after the
-  //  proposal is processed.
-  const showPostProcessAction =
-    adapterName === ContractAdapterNames.distribute &&
-    status === ProposalFlowStatus.Completed &&
-    daoProposalVoteResult &&
-    VotingState[daoProposalVoteResult] === VotingState[VotingState.PASS];
 
   /**
    * If a render prop was provided it will render it and pass
@@ -132,14 +121,6 @@ export default function ProposalWithOffchainVoteActions(
           disabled={status === ProposalFlowStatus.OffchainVotingGracePeriod}
           proposal={proposal}
         />
-      );
-    }
-
-    // Post-process button
-    // @todo Remove and use render prop
-    if (showPostProcessAction) {
-      return (
-        <PostProcessAction adapterName={adapterName} proposal={proposal} />
       );
     }
   }

--- a/src/components/proposals/ProposalWithOffchainVoteActions.tsx
+++ b/src/components/proposals/ProposalWithOffchainVoteActions.tsx
@@ -15,7 +15,6 @@ import {VotingState} from './voting/types';
 import ErrorMessageWithDetails from '../common/ErrorMessageWithDetails';
 import PostProcessAction from './PostProcessAction';
 import ProcessAction from './ProcessAction';
-import ProcessActionMembership from './ProcessActionMembership';
 import ProcessActionTribute from './ProcessActionTribute';
 import SponsorAction from './SponsorAction';
 import SubmitAction from './SubmitAction';
@@ -91,21 +90,6 @@ export default function ProposalWithOffchainVoteActions(
 
   function renderProcessAction() {
     switch (adapterName) {
-      case ContractAdapterNames.onboarding:
-        return (
-          <ProcessActionMembership
-            // Show during DAO proposal grace period, but set to disabled
-            disabled={status === ProposalFlowStatus.OffchainVotingGracePeriod}
-            proposal={proposal}
-            isProposalPassed={
-              !!(
-                daoProposalVoteResult &&
-                VotingState[daoProposalVoteResult] ===
-                  VotingState[VotingState.PASS]
-              )
-            }
-          />
-        );
       case ContractAdapterNames.tribute:
         return (
           <ProcessActionTribute

--- a/src/pages/membership/MembershipDetails.tsx
+++ b/src/pages/membership/MembershipDetails.tsx
@@ -63,7 +63,7 @@ export default function MembershipDetails() {
    */
 
   // Render any adapter-specific actions
-  function renderAction(data: RenderActionPropArguments) {
+  function renderAction(data: RenderActionPropArguments): React.ReactNode {
     const {
       OffchainVotingContract: {daoProposalVoteResult, proposal, status},
     } = data;

--- a/src/pages/membership/MembershipDetails.tsx
+++ b/src/pages/membership/MembershipDetails.tsx
@@ -72,18 +72,19 @@ export default function MembershipDetails() {
       status === ProposalFlowStatus.Process ||
       status === ProposalFlowStatus.OffchainVotingGracePeriod
     ) {
+      if (
+        daoProposalVoteResult &&
+        VotingState[daoProposalVoteResult] !== VotingState[VotingState.PASS]
+      ) {
+        // Return a React.Fragment to hide the process button if proposal failed.
+        return <></>;
+      }
+
       return (
         <ProcessActionMembership
           // Show during DAO proposal grace period, but set to disabled
           disabled={status === ProposalFlowStatus.OffchainVotingGracePeriod}
           proposal={proposal}
-          isProposalPassed={
-            !!(
-              daoProposalVoteResult &&
-              VotingState[daoProposalVoteResult] ===
-                VotingState[VotingState.PASS]
-            )
-          }
         />
       );
     }

--- a/src/pages/membership/MembershipDetails.tsx
+++ b/src/pages/membership/MembershipDetails.tsx
@@ -12,6 +12,12 @@ import ProposalActions from '../../components/proposals/ProposalActions';
 import ProposalAmount from '../../components/proposals/ProposalAmount';
 import ProposalDetails from '../../components/proposals/ProposalDetails';
 import Wrap from '../../components/common/Wrap';
+import {
+  ProposalFlowStatus,
+  RenderActionPropArguments,
+} from '../../components/proposals/types';
+import {VotingState} from '../../components/proposals/voting/types';
+import ProcessActionMembership from '../../components/proposals/ProcessActionMembership';
 
 const PLACEHOLDER = '\u2014'; /* em dash */
 
@@ -51,6 +57,40 @@ export default function MembershipDetails() {
     proposalNotFound,
     proposalStatus,
   } = useProposalOrDraft(proposalId);
+
+  /**
+   * Functions
+   */
+
+  // Render any adapter-specific actions
+  function renderAction(data: RenderActionPropArguments) {
+    const {
+      OffchainVotingContract: {daoProposalVoteResult, proposal, status},
+    } = data;
+
+    if (
+      status === ProposalFlowStatus.Process ||
+      status === ProposalFlowStatus.OffchainVotingGracePeriod
+    ) {
+      return (
+        <ProcessActionMembership
+          // Show during DAO proposal grace period, but set to disabled
+          disabled={status === ProposalFlowStatus.OffchainVotingGracePeriod}
+          proposal={proposal}
+          isProposalPassed={
+            !!(
+              daoProposalVoteResult &&
+              VotingState[daoProposalVoteResult] ===
+                VotingState[VotingState.PASS]
+            )
+          }
+        />
+      );
+    }
+
+    // Return `null` to signal to use default actions
+    return null;
+  }
 
   /**
    * Render
@@ -121,6 +161,7 @@ export default function MembershipDetails() {
             <ProposalActions
               adapterName={ContractAdapterNames.onboarding}
               proposal={proposalData}
+              renderAction={renderAction}
             />
           )}
         />

--- a/src/pages/transfers/TransferDetails.tsx
+++ b/src/pages/transfers/TransferDetails.tsx
@@ -13,7 +13,7 @@ import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDet
 import FadeIn from '../../components/common/FadeIn';
 import LoaderLarge from '../../components/feedback/LoaderLarge';
 import NotFound from '../subpages/NotFound';
-import PostProcessAction from '../../components/proposals/PostProcessAction';
+import PostProcessActionTransfer from '../../components/proposals/PostProcessActionTransfer';
 import ProposalActions from '../../components/proposals/ProposalActions';
 import ProposalAmount from '../../components/proposals/ProposalAmount';
 import ProposalDetails from '../../components/proposals/ProposalDetails';
@@ -65,26 +65,17 @@ export default function TransferDetails() {
   // Render any adapter-specific actions
   function renderAction(data: RenderActionPropArguments): React.ReactNode {
     const {
-      OffchainVotingContract: {
-        adapterName,
-        daoProposalVoteResult,
-        proposal,
-        status,
-      },
+      OffchainVotingContract: {daoProposalVoteResult, proposal, status},
     } = data;
 
-    //  Currently, only Distribute adapter has an action that occurs after the
-    //  proposal is processed.
-    const showPostProcessAction =
-      adapterName === ContractAdapterNames.distribute &&
+    //  The Distribute adapter has an additional action after a passed proposal
+    //  is processed to handle the actual asset distribution.
+    if (
       status === ProposalFlowStatus.Completed &&
       daoProposalVoteResult &&
-      VotingState[daoProposalVoteResult] === VotingState[VotingState.PASS];
-
-    if (showPostProcessAction) {
-      return (
-        <PostProcessAction adapterName={adapterName} proposal={proposal} />
-      );
+      VotingState[daoProposalVoteResult] === VotingState[VotingState.PASS]
+    ) {
+      return <PostProcessActionTransfer proposal={proposal} />;
     }
 
     // Return `null` to signal to use default actions

--- a/src/pages/tributes/TributeDetails.tsx
+++ b/src/pages/tributes/TributeDetails.tsx
@@ -72,18 +72,19 @@ export default function TributeDetails() {
       status === ProposalFlowStatus.Process ||
       status === ProposalFlowStatus.OffchainVotingGracePeriod
     ) {
+      if (
+        daoProposalVoteResult &&
+        VotingState[daoProposalVoteResult] !== VotingState[VotingState.PASS]
+      ) {
+        // Return a React.Fragment to hide the process button if proposal failed.
+        return <></>;
+      }
+
       return (
         <ProcessActionTribute
           // Show during DAO proposal grace period, but set to disabled
           disabled={status === ProposalFlowStatus.OffchainVotingGracePeriod}
           proposal={proposal}
-          isProposalPassed={
-            !!(
-              daoProposalVoteResult &&
-              VotingState[daoProposalVoteResult] ===
-                VotingState[VotingState.PASS]
-            )
-          }
         />
       );
     }


### PR DESCRIPTION
Fixes #283 

✨ **Updates**

 - Migrates Onboarding process action to be rendered inside a render prop in `ProposalActions`
 - Migrates Tribute process action to be rendered inside a render prop in `ProposalActions`
 - Migrates Distribute post-process action to be rendered inside a render prop in `ProposalActions`
 - Changes `PostProcessAction` to `PostProcessActionTransfer` for specific use with the Distribute adapter (no longer intended to be generic)
 
⛔️ **Removes**

 - `isProposalPassed` prop from onboarding process action
 - `isProposalPassed` prop from tribute process action