### PR TITLE
Skip processing proposal when no snapshot votes submitted

### DIFF
--- a/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
+++ b/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
@@ -36,6 +36,7 @@ export function useProposalWithOffchainVoteStatus(
   proposal: ProposalData
 ): UseProposalWithOffchainVoteStatusReturn {
   const {daoProposalVotingAdapter, snapshotDraft, snapshotProposal} = proposal;
+  const {votes: snapshotVotes} = snapshotProposal || {};
   const proposalId = snapshotDraft?.idInDAO || snapshotProposal?.idInDAO;
 
   /**
@@ -286,6 +287,21 @@ export function useProposalWithOffchainVoteStatus(
     atSponsoredInDAO
   ) {
     return getReturnData(ProposalFlowStatus.OffchainVoting);
+  }
+
+  // Status: If no votes, skip `OffchainVotingSubmitResult` and set to `OffchainVotingGracePeriod` or `Process`
+  if (
+    votingTimeStartEndInitReady &&
+    hasVotingTimeEnded &&
+    atSponsoredInDAO &&
+    !snapshotVotes?.length &&
+    !offchainResultSubmitted
+  ) {
+    return getReturnData(
+      isInVotingGracePeriod
+        ? ProposalFlowStatus.OffchainVotingGracePeriod
+        : ProposalFlowStatus.Process
+    );
   }
 
   // Status: Ready to Submit Vote Result


### PR DESCRIPTION
Fixes #260 

✨ **Updates**

 - Adds off-chain status unit tests for when no snapshot votes submitted
 
🐞 **Bugs squashed**

 - Proposal actions:  Skips processing action when no snapshot proposal votes
 - Proposal listing:  (todo)
